### PR TITLE
rubocop 0.88 + test-prof 0.11+ don't play nice together. This fixes that

### DIFF
--- a/lib/test_prof/cops/rspec/aggregate_examples.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples.rb
@@ -108,7 +108,7 @@ module RuboCop
       #     expect(number).to be_odd
       #   end
       #
-      class AggregateExamples < Cop
+      class AggregateExamples < ::RuboCop::Cop::Cop
         include LineRangeHelpers
         include MetadataHelpers
         include NodeMatchers

--- a/lib/test_prof/cops/rspec/aggregate_examples/its.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/its.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < Cop
+      class AggregateExamples < ::RuboCop::Cop::Cop
         # @example `its`
         #
         #   # Supports regular `its` call with an attribute/method name,

--- a/lib/test_prof/cops/rspec/aggregate_examples/line_range_helpers.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/line_range_helpers.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < Cop
+      class AggregateExamples < ::RuboCop::Cop::Cop
         # @internal Support methods for keeping newlines around examples.
         module LineRangeHelpers
           include RangeHelp

--- a/lib/test_prof/cops/rspec/aggregate_examples/matchers_with_side_effects.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/matchers_with_side_effects.rb
@@ -5,7 +5,7 @@ require_relative "../language"
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < Cop
+      class AggregateExamples < ::RuboCop::Cop::Cop
         # When aggregated, the expectations will fail when not supposed to or
         # have a risk of not failing when expected to. One example is
         # `validate_presence_of :comment` as it leaves an empty comment after

--- a/lib/test_prof/cops/rspec/aggregate_examples/metadata_helpers.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/metadata_helpers.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < Cop
+      class AggregateExamples < ::RuboCop::Cop::Cop
         # @internal
         #   Support methods for example metadata.
         #   Examples with similar metadata are grouped.

--- a/lib/test_prof/cops/rspec/aggregate_examples/node_matchers.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/node_matchers.rb
@@ -5,7 +5,7 @@ require_relative "../language"
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < Cop
+      class AggregateExamples < ::RuboCop::Cop::Cop
         # @internal
         #   Node matchers and searchers.
         module NodeMatchers


### PR DESCRIPTION
### What is the purpose of this pull request?
after updating rubocop to 0.88 and test-prof to 0.12, I started getting this error:

```
An error occurred while RSpec/AggregateFailures cop was inspecting /Users/michaelglass/Documents/work/NoRedInk/monolith/spec/controllers/cool_controller_spec.rb:338:6.
unknown keyword: location
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/base.rb:106:in `add_offense'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples.rb:127:in `block (3 levels) in on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples.rb:126:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples.rb:126:in `block (2 levels) in on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples.rb:125:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples.rb:125:in `block in on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples/node_matchers.rb:36:in `example_group_with_several_examples'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/test-prof-0.12.0/lib/test_prof/cops/rspec/aggregate_examples.rb:124:in `on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:91:in `block (2 levels) in trigger_responding_cops'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:113:in `with_cop_error_handling'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:90:in `block in trigger_responding_cops'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:89:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:89:in `trigger_responding_cops'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:61:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `block in on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:173:in `on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `block in on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:173:in `on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `block in on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:173:in `on_block'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `block in on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:59:in `on_begin'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:62:in `block (2 levels) in <class:Commissioner>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-ast-0.2.0/lib/rubocop/ast/traversal.rb:14:in `walk'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/commissioner.rb:74:in `investigate'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/team.rb:151:in `investigate_partial'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cop/team.rb:83:in `investigate'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:295:in `inspect_file'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:245:in `block in do_inspection_loop'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:277:in `block in iterate_until_no_changes'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:270:in `loop'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:270:in `iterate_until_no_changes'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:241:in `do_inspection_loop'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:121:in `block in file_offenses'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:146:in `file_offense_cache'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:120:in `file_offenses'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:111:in `process_file'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:90:in `block in each_inspected_file'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:89:in `each'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:89:in `reduce'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:89:in `each_inspected_file'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:78:in `inspect_files'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/runner.rb:39:in `run'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli/command/execute_runner.rb:21:in `execute_runner'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli/command/execute_runner.rb:13:in `run'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli/command.rb:10:in `run'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli/environment.rb:17:in `run'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli.rb:65:in `run_command'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli.rb:72:in `execute_runners'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/lib/rubocop/cli.rb:41:in `run'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/exe/rubocop:13:in `block in <top (required)>'
/nix/store/7knbg9848wkdifxrfzb9dfn6vpf7pwpf-ruby-2.6.6/lib/ruby/2.6.0/benchmark.rb:308:in `realtime'
/Users/michaelglass/Documents/work/NoRedInk/monolith/_build/gems/ruby/2.6.0/gems/rubocop-0.88.0/exe/rubocop:12:in `<top (required)>'
/Users/michaelglass/Documents/work/NoRedInk/monolith/bin/rubocop:29:in `load'
/Users/michaelglass/Documents/work/NoRedInk/monolith/bin/rubocop:29:in `<main>'
.

1 file inspected, no offenses detected

8 errors occurred:
An error occurred while RSpec/AggregateExamples cop was inspecting /Users/michaelglass/Documents/work/NoRedInk/monolith/spec/controllers/cool_controller_spec.rb:292:6.
```

this change fixes it. Regression (maybe?) was introduced here: https://github.com/test-prof/test-prof/pull/170

### What changes did you make? (overview)
TBH I don't know why `< Cop` wasn't inheriting from `RuboCop::Cop::Cop` but it wasn't. Now it is.

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation