### PR TITLE
Fix let_it_be with Rails3 when outside of transactions

### DIFF
--- a/lib/test_prof/ext/active_record_3.rb
+++ b/lib/test_prof/ext/active_record_3.rb
@@ -5,8 +5,8 @@ module TestProf
   module ActiveRecord3Transactions
     refine ::ActiveRecord::ConnectionAdapters::AbstractAdapter do
       def begin_transaction(joinable: true)
-        increment_open_transactions
         if open_transactions > 0
+          increment_open_transactions
           create_savepoint
         else
           begin_db_transaction


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

# What is the purpose of this pull request?

When usig `let_it_be` in Rails3 outside of a transaction the following error appears: `ActiveRecord::StatementInvalid: Mysql2::Error: SAVEPOINT active_record_1 does not exist: ROLLBACK TO SAVEPOINT active_record_1`

The issue is that `increment_open_transactions` is called before `if open_transactions > 0` check which implies that a new transaction is never created.
This PR fixes the issue by moving  `increment_open_transactions` within the if statement: this allows the creation of a transaction when is needed.

Fixes #197


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation

-->
