### PR TITLE
Add RuboCop RSpec support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unrealeased)
 
+- Add support for RSpec aliases detection when linting specs using `let_it_be`/`before_all` with `rubocop-rspec` 2.0 ([@pirj][])
+
 ## 0.12.2 (2020-09-03)
 
 - Execute Minitest `before_all` in the context of the current test object. ([@palkan][])

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,0 +1,6 @@
+RSpec:
+  Language:
+    Helpers:
+      - let_it_be
+    Hooks:
+      - before_all

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,16 @@ Supported Ruby versions:
 
 Supported RSpec version (for RSpec features only): >= 3.5.0 (for older RSpec version use TestProf < 0.8.0).
 
+### Linting with RuboCop RSpec
+
+When you lint your RSpec spec files with `rubocop-rspec`, it will fail to properly detect RSpec constructs that TestProf defines, `let_it_be` and `before_all`.
+Make sure to use `rubocop-rspec` 2.0 or newer and add the following to your `.rubocop.yml`:
+
+```yaml
+inherit_gem:
+  test-prof: config/rubocop-rspec.yml
+```
+
 ## Profilers
 
 - [RubyProf Integration](./profilers/ruby_prof.md)


### PR DESCRIPTION
### What is the purpose of this pull request?

Previously, RuboCop RSpec failed to detect RSpec aliases. A number of cops were failing false offences, and some cops were unable to lint, as they were skipping locally defined RSpec aliases taking them for arbitrary blocks and method calls.

See:
 - rubocop-hq/rubocop-rspec#1077
 - rubocop-hq/rubocop-rspec#956

Sibling pull requests:
 - https://github.com/palkan/action_policy/pull/138

`Gemfile`:
```ruby
# frozen_string_literal: true

source 'https://rubygems.org'

gem 'rubocop-rspec'
gem 'test-prof', path: '../../test-prof'
```

`.rubocop.yml`:
```yaml
require:
  - rubocop-rspec

inherit_gem:
  test-prof: .rubocop-rspec-aliases.yml
```

`spec/o_spec.rb`:
```ruby
# frozen_string_literal: true

RSpec.describe 'O' do
  let_it_be(:x) { 'the_one_and_only' }

  # I must come above any other memoized helper! (disclaimer: due to an arguable default linter setting)
  subject(:o) { 'everchanging' } # Not really everchanging with a frozen_string_literal

  it { expect(o).not_to eq("#{x}#{x}") }
end
```

#### Before (`let_it_be` is not detected as a memoized helper)
```
$ rubocop
Inspecting 2 files
..

2 files inspected, no offenses detected
```
#### After (`let_it_be` is properly detected)
```
$ rubocop
Inspecting 2 files
.C

Offenses:

spec/o_spec.rb:7:3: C: RSpec/LeadingSubject: Declare subject above any other let_it_be declarations.
  subject(:o) { 'everchanging' } # Not really everchanging with a frozen_string_literal
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

2 files inspected, 1 offense detected, 1 offense auto-correctable
```

### What changes did you make? (overview)

 - added an RSpec alias config file that RuboCop is able to load and append to the default RuboCop RSpec alias configuration.
 - added docs on how to tell RuboCop to use those aliases

### Is there anything you'd like reviewers to focus on?

Should I through in some test to make sure the detection works as expected?

I don't have a project that uses `let_it_be`/`before_all` handy at the moment.
Do you mind to checking this against a live project?

### Checklist

- [-] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation