### PR TITLE
before_all improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unrealeased)
 
+- Minitest's `before_all` is not longer experimental. ([@palkan][])
+
+- Add `after_all` to Minitest in addition to `before_all`. ([@palkan][])
+
 ## 1.0.0.rc1 (2020-12-30)
 
 - Remove deprecated `AggregateFailures` cop. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unrealeased)
 
+- Make Rails fixtures accesible in `before_all`. ([@palkan][])
+
+You can load and access fixtures when explicitly enabling them via `before_all(setup_fixtures: true, &block)`.
+
 - Minitest's `before_all` is not longer experimental. ([@palkan][])
 
 - Add `after_all` to Minitest in addition to `before_all`. ([@palkan][])

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ Add `test-prof` gem to your application:
 
 ```ruby
 group :test do
-  gem "test-prof"
+  gem "test-prof", "1.0.0.rc1"
 end
 ```
 
@@ -87,6 +87,8 @@ Supported Ruby versions:
 - JRuby >= 9.1.0.0 (**NOTE:** refinements-dependent features might require 9.2.7+)
 
 Supported RSpec version (for RSpec features only): >= 3.5.0 (for older RSpec version use TestProf < 0.8.0).
+
+Supported Rails version (for Rails features only): >= 5.2.0 (for older Rails versions use TestProf < 1.0).
 
 ### Linting with RuboCop RSpec
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,7 +6,7 @@ Add `test-prof` gem to your application:
 
 ```ruby
 group :test do
-  gem "test-prof"
+  gem "test-prof", "1.0.0.rc1"
 end
 ```
 

--- a/docs/recipes/before_all.md
+++ b/docs/recipes/before_all.md
@@ -73,9 +73,7 @@ tests in a database transaction of its own. Use Rails' native `use_transactional
 DatabaseCleaner, or custom code that begins a transaction before each test and rolls it
 back after.
 
-### Minitest (Experimental)
-
-\*_Experimental_ means that I haven't tried it in _production_.
+### Minitest
 
 It is possible to use `before_all` with Minitest too:
 
@@ -95,6 +93,8 @@ class MyBeatlesTest < Minitest::Test
   # define tests which could access the object defined within `before_all`
 end
 ```
+
+In addition to `before_all`, TestProf also provides a `after_all` callback, which is called right before the transaction open by `before_all` is closed, i.e., after the last example from the test class completes.
 
 ## Database adapters
 

--- a/docs/recipes/before_all.md
+++ b/docs/recipes/before_all.md
@@ -216,3 +216,24 @@ Alternatively, you can load the patch explicitly:
 # after loading before_all or/and let_it_be
 require "test_prof/before_all/isolator"
 ```
+
+## Using Rails fixtures (_experimental_)
+
+If you want to use fixtures within a `before_all` hook, you must explicitly opt-in via `setup_fixture:` option:
+
+```ruby
+before_all(setup_fixtures: true) do
+  @user = users(:john)
+  @post = create(:post, user: user)
+end
+```
+
+Works for both Minitest and RSpec.
+
+You can also enable fixtures globally (i.e., for all `before_all` hooks):
+
+```ruby
+TestProf::BeforeAll.configure do |config|
+  config.setup_fixtures = true
+end
+```

--- a/lib/test_prof/before_all.rb
+++ b/lib/test_prof/before_all.rb
@@ -32,6 +32,12 @@ module TestProf
         end
       end
 
+      def setup_fixtures(test_object)
+        raise ArgumentError, "Current adapter doesn't support #setup_fixtures" unless adapter.respond_to?(:setup_fixtures)
+
+        adapter.setup_fixtures(test_object)
+      end
+
       def config
         @config ||= Configuration.new
       end
@@ -60,8 +66,11 @@ module TestProf
     class Configuration
       HOOKS = %i[begin rollback].freeze
 
+      attr_accessor :setup_fixtures
+
       def initialize
         @hooks = Hash.new { |h, k| h[k] = HooksChain.new(k) }
+        @setup_fixtures = false
       end
 
       # Add `before` hook for `begin` or

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -18,6 +18,20 @@ module TestProf
             end
             ::ActiveRecord::Base.connection.rollback_transaction
           end
+
+          def setup_fixtures(test_object)
+            test_object.instance_eval do
+              @@already_loaded_fixtures ||= {}
+              @fixture_cache ||= {}
+
+              if @@already_loaded_fixtures[self.class]
+                @loaded_fixtures = @@already_loaded_fixtures[self.class]
+              else
+                @loaded_fixtures = load_fixtures(config)
+                @@already_loaded_fixtures[self.class] = @loaded_fixtures
+              end
+            end
+          end
         end
       end
     end

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -75,7 +75,7 @@ module TestProf
           self.before_all_executor = Executor.new(&block)
 
           prepend(Module.new do
-            def setup
+            def before_setup
               self.class.before_all_executor.activate!(self)
               super
             end

--- a/lib/test_prof/recipes/rspec/before_all.rb
+++ b/lib/test_prof/recipes/rspec/before_all.rb
@@ -6,14 +6,22 @@ module TestProf
   module BeforeAll
     # Helper to wrap the whole example group into a transaction
     module RSpec
-      def before_all(&block)
+      def before_all(setup_fixtures: BeforeAll.config.setup_fixtures, &block)
         raise ArgumentError, "Block is required!" unless block_given?
 
-        return before(:all, &block) if within_before_all?
+        if within_before_all?
+          before(:all) do
+            @__inspect_output = "before_all hook"
+            instance_eval(&block)
+          end
+          return
+        end
 
         @__before_all_activated__ = true
 
         before(:all) do
+          @__inspect_output = "before_all hook"
+          BeforeAll.setup_fixtures(self) if setup_fixtures
           BeforeAll.begin_transaction do
             instance_eval(&block)
           end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -108,8 +108,9 @@ module TestProf
 
       LetItBe.module_for(self).module_eval do
         define_method(identifier) do
-          # Trying to detect the context (couldn't find other way so far)
-          if /\(:context\)/.match?(@__inspect_output)
+          # Trying to detect the context
+          # Based on https://github.com/rspec/rspec-rails/commit/7cb796db064f58da7790a92e73ab906ef50b1f34
+          if @__inspect_output.include?("before(:context)") || @__inspect_output.include?("before_all")
             instance_variable_get(:"#{PREFIX}#{identifier}")
           else
             # Fallback to let definition

--- a/spec/integrations/before_all_spec.rb
+++ b/spec/integrations/before_all_spec.rb
@@ -35,5 +35,11 @@ describe "BeforeAll" do
 
       expect(output).to include("0 failures, 0 errors, 0 skips")
     end
+
+    specify "after_all" do
+      output = run_minitest("before_all")
+
+      expect(output).to include("WE ALL HUMANS AFTER ALL: 1")
+    end
   end
 end

--- a/spec/integrations/fixtures/minitest/before_all_fixture.rb
+++ b/spec/integrations/fixtures/minitest/before_all_fixture.rb
@@ -15,6 +15,10 @@ describe "User" do
     @user = TestProf::FactoryBot.create(:user, name: user_name)
   end
 
+  after_all do
+    $stdout.puts "WE ALL HUMANS AFTER ALL: #{User.count}"
+  end
+
   def user_name
     %w[Matroskin Sharik].sample
   end

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -139,7 +139,8 @@ RSpec.describe "User", :transactional do
 
     let_it_be(:user, reload: true) { @user }
 
-    let_it_be(:post) { create(:post, user: user) }
+    before_all { @post = create(:post, user: user) }
+    let_it_be(:post) { @post }
 
     specify do
       expect(post.user).to eq @user


### PR DESCRIPTION
### What is the purpose of this pull request?

Improve `before_all` for Minitest.

### What changes did you make? (overview)

- [x] Fixed Minitest integration (use `before_setup` instead of `setup`, handle filtering)
- [x] Added `after_all`
- [x] Added fixtures support (for both Mintiest and RSpec)  

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

