### PR TITLE
When strings are frozen, we can't modify FrozenError message

### DIFF
--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -91,7 +91,7 @@ module TestProf
       initializer = proc do
         instance_variable_set(:"#{TestProf::LetItBe::PREFIX}#{identifier}", instance_exec(&block))
       rescue FrozenError => e
-        e.message << TestProf::LetItBe::FROZEN_ERROR_HINT
+        e.message << TestProf::LetItBe::FROZEN_ERROR_HINT unless e.message.frozen?
         raise
       end
 
@@ -243,7 +243,7 @@ end
 RSpec.configure do |config|
   config.after(:example) do |example|
     if example.exception&.is_a?(FrozenError)
-      example.exception.message << TestProf::LetItBe::FROZEN_ERROR_HINT
+      example.exception.message << TestProf::LetItBe::FROZEN_ERROR_HINT unless example.exception.message.frozen?
     end
   end
 end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -91,8 +91,7 @@ module TestProf
       initializer = proc do
         instance_variable_set(:"#{TestProf::LetItBe::PREFIX}#{identifier}", instance_exec(&block))
       rescue FrozenError => e
-        e.message << TestProf::LetItBe::FROZEN_ERROR_HINT unless e.message.frozen?
-        raise
+        raise e.exception("#{e.message}#{TestProf::LetItBe::FROZEN_ERROR_HINT}")
       end
 
       default_options = LetItBe.config.default_modifiers.dup


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

Fixes #203 


### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?
Is there a better strategy you'd like me to implement ? How should we get the FROZEN_ERROR_HINT to users when strings are frozen ?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
