### PR TITLE
Updated call to reporting_enabled?

### DIFF
--- a/lib/test_prof/recipes/rspec/any_fixture.rb
+++ b/lib/test_prof/recipes/rspec/any_fixture.rb
@@ -15,7 +15,7 @@ RSpec.configure do |config|
   config.include_context "any_fixture:clean", with_clean_fixture: true
 
   config.after(:suite) do
-    TestProf::AnyFixture.report_stats if TestProf::AnyFixture.reporting_enabled?
+    TestProf::AnyFixture.report_stats if TestProf::AnyFixture.config.reporting_enabled?
     TestProf::AnyFixture.reset
   end
 end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


### What is the purpose of this pull request?
I don't specifically use AnyFixtures so I was wondering why it was suddenly popping up whenever I ran my specs:

![image](https://user-images.githubusercontent.com/46548/107728364-d388a800-6d28-11eb-9dac-ee2f1e468669.png)

This PR fixes that outdated call.

After:

![image](https://user-images.githubusercontent.com/46548/107728469-21051500-6d29-11eb-83ec-11faacce715d.png)

### What changes did you make? (overview)
I followed the deprecation message and updated the call to use the config object instead of the [deprecated] class method

### Checklist
I don't think it's needed since it's an internal change, but let me know if it is :) 

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
