### PR TITLE
Require tsort library

### DIFF
--- a/lib/test_prof/ruby_prof.rb
+++ b/lib/test_prof/ruby_prof.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tsort"
+
 module TestProf
   # RubyProf wrapper.
   #


### PR DESCRIPTION
### What is the purpose of this pull request?

With a non-Rails project, minitest, test-prof, and ruby-prof, and invoking tests with `TEST_RUBY_PROF=1 rake test`, I'd receive a `NameError` for `TSort`.

```
/usr/local/bundle/gems/test-prof-1.0.2/lib/test_prof/ruby_prof.rb:243:in `exclude_common_methods': uninitialized constant #<Class:TestProf::RubyProf>::TSort (NameError)
```

### What changes did you make? (overview)

Require `tsort` library at top of file using `TSort`.

### Is there anything you'd like reviewers to focus on?

None.

### Checklist

- I've added tests for this change - no, but open to this one if you feel it's worth it.
- ~I've added a Changelog entry~ NA?
- ~I've updated a documentation~ NA?