### PR TITLE
Suggest require: false on bundling the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Add `test-prof` gem to your application:
 
 ```ruby
 group :test do
-  gem "test-prof", "~> 1.0"
+  gem "test-prof", "~> 1.0", require: false
 end
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ Add `test-prof` gem to your application:
 
 ```ruby
 group :test do
-  gem "test-prof", "~> 1.0"
+  gem "test-prof", "~> 1.0", require: false
 end
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,7 +6,7 @@ Add `test-prof` gem to your application:
 
 ```ruby
 group :test do
-  gem "test-prof", "~> 1.0"
+  gem "test-prof", "~> 1.0", require: false
 end
 ```
 


### PR DESCRIPTION
RubyMine, for example, is running after every `bundle install` the `rake --tasks` command, which fails if not specifying `require: false`:

```bash
23:10 $ rake --tasks --trace
rake aborted!
NameError: uninitialized constant RSpec::Core
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof/rspec_dissect.rb:87:in `init'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof/rspec_dissect.rb:145:in `block in <top (required)>'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof.rb:75:in `block in activate'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof.rb:105:in `activate!'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof.rb:75:in `activate'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof/rspec_dissect.rb:144:in `<top (required)>'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test_prof.rb:164:in `<top (required)>'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/test-prof-1.0.2/lib/test-prof.rb:3:in `<top (required)>'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `require'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `each'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:76:in `block in require'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `each'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:65:in `require'
/Users/thunder/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-1.17.3/lib/bundler.rb:114:in `require'
```

[skip ci]
