### PR TITLE
Add support for (process) parallelized tests to before_all (minitest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix access to `let_it_be` variables in `after(:all)` hook. ([@cbarton][])
 
+- Add support for using the before_all hook with Rails' parallelize feature (using processes). ([@peret][])
+
+Make sure to include `TestProf::BeforeAll::Minitest` before you call `parallelize`.
+
 ## 1.0.6 (2021-06-23)
 
 - Fix Spring detection when `DISABLE_SPRING=1` is used. ([@palkan][])

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -6,10 +6,10 @@ Minitest.singleton_class.prepend(Module.new do
   @previous_klass = nil
 
   def run_one_method(klass, method_name)
-    return super unless klass.before_all_executor && klass.parallelized
+    return super unless klass.parallelized
 
     if @previous_klass && @previous_klass != klass
-      klass.before_all_executor.deactivate!
+      @previous_klass.before_all_executor&.deactivate!
     end
     @previous_klass = klass
 

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -100,11 +100,13 @@ module TestProf
         def included(base)
           base.extend ClassMethods
 
-          base.singleton_class.cattr_accessor :parallelized
-          base.parallelize_teardown do
-            last_klass = ::Minitest.previous_klass
-            if last_klass&.respond_to?(:parallelized) && last_klass.parallelized
-              last_klass.before_all_executor&.deactivate!
+          base.cattr_accessor :parallelized
+          if base.respond_to?(:parallelize_teardown)
+            base.parallelize_teardown do
+              last_klass = ::Minitest.previous_klass
+              if last_klass&.respond_to?(:parallelized) && last_klass&.parallelized
+                last_klass.before_all_executor&.deactivate!
+              end
             end
           end
 

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -110,25 +110,27 @@ module TestProf
             end
           end
 
-          base.singleton_class.prepend(Module.new do
-            def parallelize(workers: :number_of_processors, with: :processes)
-              # super.parallelize returns nil when no parallelization is set up
-              if super(workers: workers, with: with).nil?
-                return
-              end
+          if base.respond_to?(:parallelize)
+            base.singleton_class.prepend(Module.new do
+              def parallelize(workers: :number_of_processors, with: :processes)
+                # super.parallelize returns nil when no parallelization is set up
+                if super(workers: workers, with: with).nil?
+                  return
+                end
 
-              case with
-              when :processes
-                self.parallelized = true
-              when :threads
-                warn "!!! before_all is not implemented for parallalization with threads and " \
-                   "could work incorrectly"
-              else
-                warn "!!! tests are using an unknown parallelization strategy and before_all " \
-                   "could work incorrectly"
+                case with
+                when :processes
+                  self.parallelized = true
+                when :threads
+                  warn "!!! before_all is not implemented for parallalization with threads and " \
+                    "could work incorrectly"
+                else
+                  warn "!!! tests are using an unknown parallelization strategy and before_all " \
+                    "could work incorrectly"
+                end
               end
-            end
-          end)
+            end)
+          end
         end
       end
 


### PR DESCRIPTION
### What is the purpose of this pull request?
I tried running a test suite using the before_all hook in parallel (using processes) [and it didn't work as intended.](https://github.com/test-prof/test-prof/discussions/211) This PR attempts to fix that. To reiterate my comment from that thread, the issue is that during parallelized execution, an overridden run-method is used to enqueue testing  jobs in a thread-/process-safe manner and this method returns immediately after enqueuing, before any of the tests are run. Therefore, we mustn't roll back the transaction at that point.

### What changes did you make? (overview)
This change is based on a monkey-patch for the class `ActiveSupport::Testing::Parallelization::Server`, which wraps a process-safe queue that Rails uses to distribute the test cases. It adds a simple list of testing jobs that are being pushed and popped and after each test case, checks the _next_ job in the queue. If it is of a different class than the class the module was included in, we know that all test cases of that class have finished (or will be by another process) and can roll back the transaction. This works, because this is a FIFO queue and the test cases from each file are pushed one by one, i.e. tests cases from different files are not mixed in the order of the queue.

This change only handles parallelization via processes and more work is needed to also support threads. I might have a stab at that later, but this is my main use-case right now, so I would be glad to see this merged already.

### Is there anything you'd like reviewers to focus on?
I'm open to any suggestions of how to make this change simpler/more elegant, e.g. how to achieve this without the monkey-patch. Also, I only tested this with my current Rails version, 6.0.3.6, so far.

### Checklist

- [❌] I've added tests for this change
- [✅] I've added a Changelog entry
- [❌] I've updated a documentation