### PR TITLE
Allow access to `let_it_be` defined variables in after(:context)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unrealeased)
 
+- Fix access to `let_it_be` variables in `after(:all)` hook. ([@cbarton][])
+
 ## 1.0.6 (2021-06-23)
 
 - Fix Spring detection when `DISABLE_SPRING=1` is used. ([@palkan][])

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -107,7 +107,7 @@ module TestProf
         define_method(identifier) do
           # Trying to detect the context
           # Based on https://github.com/rspec/rspec-rails/commit/7cb796db064f58da7790a92e73ab906ef50b1f34
-          if @__inspect_output.include?("before(:context)") || @__inspect_output.include?("before_all")
+          if /(before|after)\(:context\)/.match?(@__inspect_output) || @__inspect_output.include?("before_all")
             instance_variable_get(:"#{PREFIX}#{identifier}")
           else
             # Fallback to let definition

--- a/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/let_it_be_fixture.rb
@@ -40,6 +40,7 @@ RSpec.describe "User", :transactional do
     let_it_be(:user) { create(:user) }
 
     before(:all) { @cache[:user_name] = user.name }
+    after(:all) { expect(user.name).to eq @cache[:user_name] }
 
     it "is cached" do
       expect(user.name).to eq @cache[:user_name]


### PR DESCRIPTION

### What is the purpose of this pull request?
Fix accessing `let_it_be` defined variables in after context hooks

### What changes did you make? (overview)
[This commit](https://github.com/test-prof/test-prof/commit/250346445396bcd892dae7d8005111a907848498) changed the way we detect the context for fetching the `let_it_be`
defined variables, matching only the `before(:context)`. Those variables
should be accessible by both before/after, so this adds back the generic
`:context` matcher to support all hooks.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
