### PR TITLE
Fix AnyFixture SQL Dump with Newlines

### DIFF
--- a/lib/test_prof/any_fixture/dump/postgresql.rb
+++ b/lib/test_prof/any_fixture/dump/postgresql.rb
@@ -23,7 +23,7 @@ module TestProf
         end
 
         def compile_sql(sql, binds)
-          sql.gsub(/\$\d+/) { binds.shift }
+          sql.gsub(/\$\d+/) { binds.shift.gsub("\n", "' || chr(10) || '") }
         end
 
         def import(path)

--- a/lib/test_prof/any_fixture/dump/sqlite.rb
+++ b/lib/test_prof/any_fixture/dump/sqlite.rb
@@ -18,7 +18,7 @@ module TestProf
         end
 
         def compile_sql(sql, binds)
-          sql.gsub(/\?/) { binds.shift }
+          sql.gsub(/\?/) { binds.shift.gsub("\n", "' || char(10) || '") }
         end
 
         def import(path)

--- a/spec/test_prof/any_fixture_spec.rb
+++ b/spec/test_prof/any_fixture_spec.rb
@@ -86,7 +86,7 @@ describe TestProf::AnyFixture, :transactional, :postgres, sqlite: :file do
       tmp_user.destroy!
 
       crypto = "crypto$5a$31$OsQLJ8tnIkCChMDcd?AiD?S.c/xUwe.Sk"
-      how_are_you = "How are you doing? OK?"
+      how_are_you = "How are you doing?\nOK?"
 
       expect do
         subject.register_dump("users") do


### PR DESCRIPTION
### What is the purpose of this pull request?
Newlines were being stripped from values when stored using `AnyFixture` SQL dumps. This was happening [here](https://github.com/test-prof/test-prof/blob/7b89b548e50a509c528ea02787348f5499f07bd0/lib/test_prof/any_fixture/dump.rb#L66). 

### What changes did you make? (overview)
In an effort to maintain the existing functionality and the format of the file, I left that above referenced line in place and replaced all newlines in values with `char(10)` or `chr(10)` depending on the database.

I updated the test to include a newline, which reproduces the issue.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
