### PR TITLE
restore the lock_thread value after rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unrealeased)
 
+- Restore the lock_thread value after rollback. ([@cou929])
+
 ## 1.0.7 (2021-08-30)
 
 - Fix access to `let_it_be` variables in `after(:all)` hook. ([@cbarton][])

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -44,7 +44,7 @@ module TestProf
       # might lead to leaking connections
       config.before(:begin) do
         next unless ::ActiveRecord::Base.connection.pool.respond_to?(:lock_thread=)
-        @orig_lock_thread = ::ActiveRecord::Base.connection.pool.instance_variable_get("@lock_thread")
+        @orig_lock_thread = ::ActiveRecord::Base.connection.pool.instance_variable_get(:@lock_thread)
         ::ActiveRecord::Base.connection.pool.lock_thread = true
       end
 

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -44,7 +44,13 @@ module TestProf
       # might lead to leaking connections
       config.before(:begin) do
         next unless ::ActiveRecord::Base.connection.pool.respond_to?(:lock_thread=)
+        @orig_lock_thread = ::ActiveRecord::Base.connection.pool.instance_variable_get("@lock_thread")
         ::ActiveRecord::Base.connection.pool.lock_thread = true
+      end
+
+      config.after(:rollback) do
+        next unless ::ActiveRecord::Base.connection.pool.respond_to?(:lock_thread=)
+        ::ActiveRecord::Base.connection.pool.lock_thread = @orig_lock_thread
       end
     end
   end

--- a/spec/integrations/before_all_spec.rb
+++ b/spec/integrations/before_all_spec.rb
@@ -27,6 +27,12 @@ describe "BeforeAll" do
       expect(output).not_to include("SampleJob")
       expect(output).to include("FailingJob")
     end
+
+    specify "database connection" do
+      output = run_rspec("before_all_connection")
+
+      expect(output).to include("0 failures")
+    end
   end
 
   context "Minitest" do
@@ -46,6 +52,12 @@ describe "BeforeAll" do
       output = run_minitest("before_all_inherit")
 
       expect(output).to include("0 failures, 0 errors, 0 skips")
+    end
+
+    specify "database connection" do
+      output = run_minitest("before_all_connection")
+
+      expect(output).to include("0 failures, 0 errors, 0 skip")
     end
   end
 end

--- a/spec/integrations/fixtures/minitest/before_all_connection_fixture.rb
+++ b/spec/integrations/fixtures/minitest/before_all_connection_fixture.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require_relative "../../../support/ar_models"
+require_relative "../../../support/transactional_minitest"
+require "minitest/autorun"
+
+require "test_prof/recipes/minitest/before_all"
+
+describe "database connection owner" do
+  describe "with before_all" do
+    include TestProf::BeforeAll::Minitest
+    before_all {}
+
+    it "uses the connection owned by main thread" do
+      main_thread = Thread.current
+      Thread.new do
+        assert_equal ActiveRecord::Base.connection.owner, main_thread
+      end.join
+    end
+  end
+
+  describe "without before_all" do
+    it "uses the connection owned by each thread" do
+      Thread.new do
+        child_thread = Thread.current
+        assert_equal ActiveRecord::Base.connection.owner, child_thread
+      end.join
+    end
+  end
+end

--- a/spec/integrations/fixtures/rspec/before_all_connection_fixture.rb
+++ b/spec/integrations/fixtures/rspec/before_all_connection_fixture.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require_relative "../../../support/ar_models"
+require_relative "../../../support/transactional_context"
+require "test_prof/recipes/rspec/before_all"
+
+describe "database connection owner" do
+  context "with before_all" do
+    before_all {}
+
+    it "uses the connection owned by main thread" do
+      main_thread = Thread.current
+      Thread.new do
+        expect(ActiveRecord::Base.connection.owner).to eq(main_thread)
+      end.join
+    end
+  end
+
+  context "without before_all" do
+    it "uses the connection owned by each thread" do
+      Thread.new do
+        child_thread = Thread.current
+        expect(ActiveRecord::Base.connection.owner).to eq(child_thread)
+      end.join
+    end
+  end
+end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Fixes #232

### What is the purpose of this pull request?

Enables testing of database connections from multiple threads in test cases that do not use before_all.

### What changes did you make? (overview)

Restore the value of `ActiveRecord::Base.connection.pool.lock_thread` after rollback.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
