### PR TITLE
Respect the printer on the configure block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## master (unrealeased)
 
-## 1.0.8 (2022-02-15
-
 - Fixes the configuration of a printer for factory_prof runs
 
 ## 1.0.7 (2021-08-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unrealeased)
 
+## 1.0.8 (2022-02-15
+
+- Fixes the configuration of a printer for factory_prof runs
+
 ## 1.0.7 (2021-08-30)
 
 - Fix access to `let_it_be` variables in `after(:all)` hook. ([@cbarton][])
@@ -267,3 +271,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@stefkin]: https://github.com/stefkin
 [@jaimerson]: https://github.com/jaimerson
 [@alexvko]: https://github.com/alexvko
+[@grillermo]: https://github.com/grillermo

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -100,13 +100,19 @@ module TestProf
       def run
         init
 
-        printer = config.printer
-
         started_at = TestProf.now
 
-        at_exit { printer.dump(result, start_time: started_at) }
+        at_exit do
+          print(started_at)
+        end
 
         start
+      end
+
+      def print(started_at)
+        printer = config.printer
+
+        printer.dump(result, start_time: started_at)
       end
 
       def start

--- a/spec/integrations/fixtures/rubocop/aggregate_failures_fixture.rb
+++ b/spec/integrations/fixtures/rubocop/aggregate_failures_fixture.rb
@@ -2,7 +2,9 @@
 
 describe "something" do
   context "many examples" do
-    it { is_expected.to be_ok }
-    it { expect(subject).to_not be_nil }
+    it do
+      is_expected.to be_ok
+      expect(subject).to_not be_nil
+    end
   end
 end

--- a/spec/test_prof/factory_prof_spec.rb
+++ b/spec/test_prof/factory_prof_spec.rb
@@ -27,26 +27,23 @@ describe TestProf::FactoryProf, :transactional do
 
     subject(:print) { described_class.print(started_at) }
 
-    it "calls the customer printer" do
+    it "calls the default printer" do
       expect(TestProf::FactoryProf::Printers::Simple).to receive(:dump)
 
       print
     end
 
     context "when the printer is customized" do
-      class CustomPrinter
-        def self.dump(result, start_time: nil)
-        end
-      end
+      let(:custom_printer) { double(dump: lambda { |result, start_time: nil| }) }
 
       before do
         described_class.configure do |config|
-          config.printer = CustomPrinter
+          config.printer = custom_printer
         end
       end
 
       it "calls the customer printer" do
-        expect(CustomPrinter).to receive(:dump)
+        expect(custom_printer).to receive(:dump)
         print
       end
     end

--- a/spec/test_prof/factory_prof_spec.rb
+++ b/spec/test_prof/factory_prof_spec.rb
@@ -22,6 +22,36 @@ describe TestProf::FactoryProf, :transactional do
     end
   end
 
+  describe "#print" do
+    let(:started_at) { Time.now }
+
+    subject(:print) { described_class.print(started_at) }
+
+    it "calls the customer printer" do
+      expect(TestProf::FactoryProf::Printers::Simple).to receive(:dump)
+
+      print
+    end
+
+    context "when the printer is customized" do
+      class CustomPrinter
+        def self.dump(result, start_time: nil)
+        end
+      end
+
+      before do
+        described_class.configure do |config|
+          config.printer = CustomPrinter
+        end
+      end
+
+      it "calls the customer printer" do
+        expect(CustomPrinter).to receive(:dump)
+        print
+      end
+    end
+  end
+
   describe "#result" do
     subject(:result) { described_class.result }
 


### PR DESCRIPTION
### What is the purpose of this pull request?
I tried customizing the FactoryProf printer and then calling rspec with
`FPROF=1 rspec ` but the custom printer configuration was not being honored, the default printer was being called, this PR fixes that problem.

```ruby
class CustomPrinter
  def self.dump(results, start_time:)
  end
end

TestProf::FactoryProf.configure do |config|
  config.printer = CustomPrinter
end
```

### What changes did you make? (overview)
I moved the code being called at exit so it could be tested independently because it is very hard to test code defined at_exit with rspec without a major refactor. 
Then moved the printer definition into that method so if in the mean time a printer is defined on a config block it is actually used. For example if it is defined on a spec_helper or a before block.

### Is there anything you'd like reviewers to focus on?
The documentation does not need updating, now what is documented is actually working.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [] I've updated a documentation

