### PR TITLE
Make defaults threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixes the configuration of a printer for factory_prof runs
 
+- Ensure that defaults are stored in a threadsafe manner
+
 ## 1.0.7 (2021-08-30)
 
 - Fix access to `let_it_be` variables in `after(:all)` hook. ([@cbarton][])

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -32,7 +32,6 @@ module TestProf
         TestProf::FactoryBot::Strategy::Build.prepend StrategyExt
         TestProf::FactoryBot::Strategy::Stub.prepend StrategyExt
 
-        @store = {}
         # default is false to retain backward compatibility
         @preserve_traits = false
       end
@@ -58,12 +57,14 @@ module TestProf
       end
 
       def reset
-        @store.clear
+        store.clear
       end
 
       private
 
-      attr_reader :store
+      def store
+        Thread.current[:testprof_factory_store] ||= {}
+      end
     end
   end
 end

--- a/spec/integrations/fixtures/rspec/factory_default_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_default_fixture.rb
@@ -83,5 +83,18 @@ describe "Post" do
         }.to change(User, :count).by(3)
       end
     end
+
+    context "thread safety" do
+      let(:user) { TestProf::FactoryBot.create(:user) }
+      let(:post) { TestProf::FactoryBot.create(:post) }
+
+      it "storing defaults is done per thread" do
+        user
+
+        Thread.new { TestProf::FactoryBot.set_factory_default(:user, user) }.join
+
+        expect(post.user).not_to eq user
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


### What is the purpose of this pull request?
To make setting a default factory threadsafe (for parallel testing)

### What changes did you make? (overview)
Instead of using an instance variable on the `FactoryDefault::DefaultSyntax` class, this change uses `Thread.current[:testprof_factory_store]`

### Is there anything you'd like reviewers to focus on?

Please let me know if I missed anything here - more than happy to make edits!

Thank you!

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
