### PR TITLE
AnyFixture callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-- Add `AnyFixture.before_reset` and `AnyFixture.after_reset` callbacks. ([@ruslanshakirov][])
+- Add `AnyFixture.before_fixtures_reset` and `AnyFixture.after_fixtures_reset` callbacks. ([@ruslanshakirov][])
 
 ## 1.0.8 (2022-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add `AnyFixture.before_reset` and `AnyFixture.after_reset` callbacks. ([@ruslanshakirov][])
+
 ## 1.0.8 (2022-03-11)
 
 - Restore the lock_thread value after rollback. ([@cou929][])
@@ -277,3 +279,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@alexvko]: https://github.com/alexvko
 [@grillermo]: https://github.com/grillermo
 [@cou929]: https://github.com/cou929
+[@ruslanshakirov]: https://github.com/ruslanshakirov

--- a/docs/recipes/any_fixture.md
+++ b/docs/recipes/any_fixture.md
@@ -35,6 +35,16 @@ RSpec.shared_context "account", account: true do
   let(:account) { Account.find(TestProf::AnyFixture.register(:account).id) }
 end
 
+# You can enhance the existing database cleaning. Posts will be deleted before reset
+TestProf::AnyFixture.before_reset do
+  Post.delete_all
+end
+
+# Or after reset
+TestProf::AnyFixture.after_reset do
+  Post.delete_all
+end
+
 # Then in your tests
 
 # Active this fixture using a tag
@@ -77,7 +87,7 @@ at_exit { TestProf::AnyFixture.clean }
 
 ## DSL
 
-We provide an optional _syntactic sugar_ (through Refinement) to make it easier to define fixtures:
+We provide an optional _syntactic sugar_ (through Refinement) to make it easier to define fixtures and use callbacks:
 
 ```ruby
 require "test_prof/any_fixture/dsl"
@@ -90,6 +100,10 @@ before(:all) { fixture(:account) }
 
 # You can also use it to fetch the record (instead of storing it in instance variable)
 let(:account) { fixture(:account) }
+
+# You can just use `before_reset` or `after_reset` callbacks
+before_reset { Post.delete_all }
+after_reset { Post.delete_all }
 ```
 
 ## `ActiveRecord#refind`

--- a/docs/recipes/any_fixture.md
+++ b/docs/recipes/any_fixture.md
@@ -35,13 +35,13 @@ RSpec.shared_context "account", account: true do
   let(:account) { Account.find(TestProf::AnyFixture.register(:account).id) }
 end
 
-# You can enhance the existing database cleaning. Posts will be deleted before reset
-TestProf::AnyFixture.before_reset do
+# You can enhance the existing database cleaning. Posts will be deleted before fixtures reset
+TestProf::AnyFixture.before_fixtures_reset do
   Post.delete_all
 end
 
 # Or after reset
-TestProf::AnyFixture.after_reset do
+TestProf::AnyFixture.after_fixtures_reset do
   Post.delete_all
 end
 
@@ -101,9 +101,9 @@ before(:all) { fixture(:account) }
 # You can also use it to fetch the record (instead of storing it in instance variable)
 let(:account) { fixture(:account) }
 
-# You can just use `before_reset` or `after_reset` callbacks
-before_reset { Post.delete_all }
-after_reset { Post.delete_all }
+# You can just use `before_fixtures_reset` or `after_fixtures_reset` callbacks
+before_fixtures_reset { Post.delete_all }
+after_fixtures_reset { Post.delete_all }
 ```
 
 ## `ActiveRecord#refind`

--- a/lib/test_prof/any_fixture.rb
+++ b/lib/test_prof/any_fixture.rb
@@ -175,9 +175,22 @@ module TestProf
 
       # Reset all information and clean tables
       def reset
+        callbacks[:before_reset].each(&:call)
+
         clean
         tables_cache.clear
         cache.clear
+
+        callbacks[:after_reset].each(&:call)
+        callbacks.clear
+      end
+
+      def before_reset(&block)
+        callbacks[:before_reset] << block
+      end
+
+      def after_reset(&block)
+        callbacks[:after_reset] << block
       end
 
       def subscriber(_event, _start, _finish, _id, data)
@@ -252,6 +265,10 @@ module TestProf
 
       def tables_cache
         @tables_cache ||= {}
+      end
+
+      def callbacks
+        @callbacks ||= Hash.new { |h, k| h[k] = [] }
       end
 
       def disable_referential_integrity

--- a/lib/test_prof/any_fixture.rb
+++ b/lib/test_prof/any_fixture.rb
@@ -175,22 +175,22 @@ module TestProf
 
       # Reset all information and clean tables
       def reset
-        callbacks[:before_reset].each(&:call)
+        callbacks[:before_fixtures_reset].each(&:call)
 
         clean
         tables_cache.clear
         cache.clear
 
-        callbacks[:after_reset].each(&:call)
+        callbacks[:after_fixtures_reset].each(&:call)
         callbacks.clear
       end
 
-      def before_reset(&block)
-        callbacks[:before_reset] << block
+      def before_fixtures_reset(&block)
+        callbacks[:before_fixtures_reset] << block
       end
 
-      def after_reset(&block)
-        callbacks[:after_reset] << block
+      def after_fixtures_reset(&block)
+        callbacks[:after_fixtures_reset] << block
       end
 
       def subscriber(_event, _start, _finish, _id, data)

--- a/lib/test_prof/any_fixture/dsl.rb
+++ b/lib/test_prof/any_fixture/dsl.rb
@@ -2,7 +2,7 @@
 
 module TestProf
   module AnyFixture
-    # Adds "global" `fixture` method (through refinement)
+    # Adds "global" `fixture`, `before_reset` and `after_reset` methods (through refinement)
     module DSL
       # Refine object, 'cause refining modules (Kernel) is vulnerable to prepend:
       # - https://bugs.ruby-lang.org/issues/13446
@@ -10,6 +10,14 @@ module TestProf
       refine ::Object do
         def fixture(id, &block)
           ::TestProf::AnyFixture.register(:"#{id}", &block)
+        end
+
+        def before_reset(&block)
+          ::TestProf::AnyFixture.before_reset(&block)
+        end
+
+        def after_reset(&block)
+          ::TestProf::AnyFixture.after_reset(&block)
         end
       end
     end

--- a/lib/test_prof/any_fixture/dsl.rb
+++ b/lib/test_prof/any_fixture/dsl.rb
@@ -2,7 +2,7 @@
 
 module TestProf
   module AnyFixture
-    # Adds "global" `fixture`, `before_reset` and `after_reset` methods (through refinement)
+    # Adds "global" `fixture`, `before_fixtures_reset` and `after_fixtures_reset` methods (through refinement)
     module DSL
       # Refine object, 'cause refining modules (Kernel) is vulnerable to prepend:
       # - https://bugs.ruby-lang.org/issues/13446
@@ -12,12 +12,12 @@ module TestProf
           ::TestProf::AnyFixture.register(:"#{id}", &block)
         end
 
-        def before_reset(&block)
-          ::TestProf::AnyFixture.before_reset(&block)
+        def before_fixtures_reset(&block)
+          ::TestProf::AnyFixture.before_fixtures_reset(&block)
         end
 
-        def after_reset(&block)
-          ::TestProf::AnyFixture.after_reset(&block)
+        def after_fixtures_reset(&block)
+          ::TestProf::AnyFixture.after_fixtures_reset(&block)
         end
       end
     end

--- a/lib/test_prof/cops/rspec/aggregate_examples/its.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/its.rb
@@ -48,14 +48,15 @@ module RuboCop
 
           def transform_its(body, arguments)
             argument = arguments.first
-            replacement = case argument.type
-                          when :array
-                            key = argument.values.first
-                            "expect(subject[#{key.source}])"
-                          else
-                            property = argument.value
-                            "expect(subject.#{property})"
-            end
+            replacement =
+              case argument.type
+              when :array
+                key = argument.values.first
+                "expect(subject[#{key.source}])"
+              else
+                property = argument.value
+                "expect(subject.#{property})"
+              end
             body.source.gsub(/is_expected|are_expected/, replacement)
           end
 

--- a/spec/integrations/fixtures/rspec/any_fixture_callbacks_fixture.rb
+++ b/spec/integrations/fixtures/rspec/any_fixture_callbacks_fixture.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require_relative "../../../support/ar_models"
+require "test_prof/recipes/rspec/any_fixture"
+
+require "test_prof/any_fixture/dsl"
+using TestProf::AnyFixture::DSL
+
+shared_context "user_and_post", user_and_post: true do
+  before(:all) do
+    @user = fixture(:user) do
+      TestProf::FactoryBot.create(:user)
+    end
+  end
+
+  before { TestProf::FactoryBot.create(:post) }
+
+  let(:user) { User.find(fixture(:user).id) }
+end
+
+describe "before_reset callback", :user_and_post do
+  before(:all) do
+    before_reset do
+      Post.delete_all
+    end
+  end
+
+  it "deletes post" do
+    expect { TestProf::AnyFixture.reset }.to change(Post, :count).by(-1)
+  end
+end
+
+describe "after_reset callback", :user_and_post do
+  before(:all) do
+    after_reset do
+      Post.delete_all
+    end
+  end
+
+  it "deletes post" do
+    expect { TestProf::AnyFixture.reset }.to change(Post, :count).by(-1)
+  end
+end
+
+describe "without callbacks", :user_and_post do
+  before { TestProf::FactoryBot.create(:post) }
+  after { Post.delete_all }
+
+  it "doesn't delete post" do
+    expect { TestProf::AnyFixture.reset }.not_to change(Post, :count)
+  end
+end

--- a/spec/integrations/fixtures/rspec/any_fixture_callbacks_fixture.rb
+++ b/spec/integrations/fixtures/rspec/any_fixture_callbacks_fixture.rb
@@ -19,9 +19,9 @@ shared_context "user_and_post", user_and_post: true do
   let(:user) { User.find(fixture(:user).id) }
 end
 
-describe "before_reset callback", :user_and_post do
+describe "before_fixtures_reset callback", :user_and_post do
   before(:all) do
-    before_reset do
+    before_fixtures_reset do
       Post.delete_all
     end
   end
@@ -31,9 +31,9 @@ describe "before_reset callback", :user_and_post do
   end
 end
 
-describe "after_reset callback", :user_and_post do
+describe "after_fixtures_reset callback", :user_and_post do
   before(:all) do
-    after_reset do
+    after_fixtures_reset do
       Post.delete_all
     end
   end

--- a/spec/test_prof/any_fixture_spec.rb
+++ b/spec/test_prof/any_fixture_spec.rb
@@ -62,10 +62,10 @@ describe TestProf::AnyFixture, :transactional, :postgres, sqlite: :file do
       expect(User.count).to eq 1
     end
 
-    context "with before_reset callback" do
+    context "with before_fixtures_reset callback" do
       it "runs callback" do
         subject.register(:user) { TestProf::FactoryBot.create(:user) }
-        subject.before_reset { Post.delete_all }
+        subject.before_fixtures_reset { Post.delete_all }
         TestProf::FactoryBot.create(:post)
 
         subject.reset
@@ -74,10 +74,10 @@ describe TestProf::AnyFixture, :transactional, :postgres, sqlite: :file do
       end
     end
 
-    context "with after_reset callback" do
+    context "with after_fixtures_reset callback" do
       it "runs callback" do
         subject.register(:user) { TestProf::FactoryBot.create(:user) }
-        subject.after_reset { Post.delete_all }
+        subject.after_fixtures_reset { Post.delete_all }
         TestProf::FactoryBot.create(:post)
 
         subject.reset

--- a/spec/test_prof/any_fixture_spec.rb
+++ b/spec/test_prof/any_fixture_spec.rb
@@ -61,6 +61,30 @@ describe TestProf::AnyFixture, :transactional, :postgres, sqlite: :file do
 
       expect(User.count).to eq 1
     end
+
+    context "with before_reset callback" do
+      it "runs callback" do
+        subject.register(:user) { TestProf::FactoryBot.create(:user) }
+        subject.before_reset { Post.delete_all }
+        TestProf::FactoryBot.create(:post)
+
+        subject.reset
+        expect(User.count).to eq 0
+        expect(Post.count).to eq 0
+      end
+    end
+
+    context "with after_reset callback" do
+      it "runs callback" do
+        subject.register(:user) { TestProf::FactoryBot.create(:user) }
+        subject.after_reset { Post.delete_all }
+        TestProf::FactoryBot.create(:post)
+
+        subject.reset
+        expect(User.count).to eq 0
+        expect(Post.count).to eq 0
+      end
+    end
   end
 
   describe "#register_dump" do

--- a/spec/test_prof/any_fixture_spec.rb
+++ b/spec/test_prof/any_fixture_spec.rb
@@ -78,7 +78,7 @@ describe TestProf::AnyFixture, :transactional, :postgres, sqlite: :file do
       it "runs callback" do
         subject.register(:user) { TestProf::FactoryBot.create(:user) }
         subject.after_fixtures_reset { Post.delete_all }
-        TestProf::FactoryBot.create(:post)
+        TestProf::FactoryBot.create(:post, user: nil)
 
         subject.reset
         expect(User.count).to eq 0


### PR DESCRIPTION
### What is the purpose of this pull request?

To add support for `AnyFixture.before_fixtures_reset` and `AnyFixture.after_fixtures_reset` callbacks, that will allow users to enhance the existing functionality of db cleaning.
### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

Closes #241
