### PR TITLE
[Typo] TagProf refers to an unexisting rspec-rails option

### DIFF
--- a/docs/profilers/tag_prof.md
+++ b/docs/profilers/tag_prof.md
@@ -2,7 +2,7 @@
 
 TagProf is a simple profiler which collects examples statistics grouped by a provided tag value.
 
-That's pretty useful in conjunction with `rspec-rails` built-in feature – `infer_spec_types_from_location!` – which automatically adds `type` to examples metadata.
+That's pretty useful in conjunction with `rspec-rails` built-in feature – `infer_spec_type_from_file_location!` – which automatically adds `type` to examples metadata.
 
 Example output:
 


### PR DESCRIPTION
I believe it meant to be [`infer_spec_type_from_file_location!`](https://github.com/rspec/rspec-rails/blob/58697211ed3a394cafe766381b928eaae109b776/lib/rspec/rails/configuration.rb#L145)