### PR TITLE
don't overwrite saved lock_thread value in nested contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fixed restoring lock_thread value in nested contexts ([@ygelfand][])
+
 ## 1.0.10 (2022-08-12)
 
 - Allow overriding global logger. ([@palkan][])
@@ -294,3 +296,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@grillermo]: https://github.com/grillermo
 [@cou929]: https://github.com/cou929
 [@ruslanshakirov]: https://github.com/ruslanshakirov
+[@ygelfand]: https://github.com/ygelfand

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -47,7 +47,7 @@ module TestProf
       # might lead to leaking connections
       config.before(:begin) do
         next unless ::ActiveRecord::Base.connection.pool.respond_to?(:lock_thread=)
-        instance_variable_set("#{PREFIX_RESTORE_LOCK_THREAD}_orig_lock_thread", ::ActiveRecord::Base.connection.pool.instance_variable_get(:@lock_thread))
+        instance_variable_set("#{PREFIX_RESTORE_LOCK_THREAD}_orig_lock_thread", ::ActiveRecord::Base.connection.pool.instance_variable_get(:@lock_thread)) unless instance_variable_defined? "#{PREFIX_RESTORE_LOCK_THREAD}_orig_lock_thread"
         ::ActiveRecord::Base.connection.pool.lock_thread = true
       end
 


### PR DESCRIPTION



In nested conexts, e.g. :
```
describe 'foo' do
  let_it_be(:foo) { 'bar' }
  describe 'bar' do
    let_it_be(:baz) { 'bax' }
    it do
      expect(true).to be_truthy
    end
  end
end
```

the saved `_orig_lock_thread` value introduced in https://github.com/test-prof/test-prof/pull/236 gets overriden, and is only restored back to `true`, this avoids re-saving thevalue if it was already saved
