### PR TITLE
Disable GC frames with TEST_STACK_PROF_IGNORE_GC=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Disable garbage collection frames when `TEST_STACK_PROF_IGNORE_GC` env variable is set ([@cbliard][])
+
 - Fixed restoring lock_thread value in nested contexts ([@ygelfand][])
 
 ## 1.0.10 (2022-08-12)

--- a/docs/profilers/stack_prof.md
+++ b/docs/profilers/stack_prof.md
@@ -76,4 +76,8 @@ You can also change StackProf interval through `TEST_STACK_PROF_INTERVAL` env va
 For modes `wall` and `cpu`, `TEST_STACK_PROF_INTERVAL` represents microseconds and will default to 1000 as per `stackprof`.
 For mode `object`, `TEST_STACK_PROF_INTERVAL` represents allocations and will default to 1 as per `stackprof`.
 
+You can disable garbage collection frames by setting `TEST_STACK_PROF_IGNORE_GC` env variable.
+Garbage collection time will still be present in the profile but not explicitly marked with
+its own frame.
+
 See [stack_prof.rb](https://github.com/test-prof/test-prof/tree/master/lib/test_prof/stack_prof.rb) for all available configuration options and their usage.

--- a/lib/test_prof/stack_prof.rb
+++ b/lib/test_prof/stack_prof.rb
@@ -24,8 +24,7 @@ module TestProf
     class Configuration
       FORMATS = %w[html json].freeze
 
-      attr_accessor :mode, :interval, :raw, :target, :format
-
+      attr_accessor :mode, :raw, :target, :format, :interval, :ignore_gc
       def initialize
         @mode = ENV.fetch("TEST_STACK_PROF_MODE", :wall).to_sym
         @target = ENV["TEST_STACK_PROF"] == "boot" ? :boot : :suite
@@ -39,6 +38,7 @@ module TestProf
 
         sample_interval = ENV["TEST_STACK_PROF_INTERVAL"].to_i
         @interval = sample_interval > 0 ? sample_interval : nil
+        @ignore_gc = ENV.fetch("TEST_STACK_PROF_IGNORE_GC", false)
       end
 
       def raw?
@@ -96,6 +96,7 @@ module TestProf
         }
 
         options[:interval] = config.interval if config.interval
+        options[:ignore_gc] = true if config.ignore_gc
 
         if block_given?
           options[:out] = build_path(name)

--- a/spec/test_prof/stack_prof_spec.rb
+++ b/spec/test_prof/stack_prof_spec.rb
@@ -42,6 +42,19 @@ describe TestProf::StackProf do
       described_class.profile
     end
 
+    specify "with ignore_gc option" do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("TEST_STACK_PROF_IGNORE_GC", any_args).and_return("1")
+
+      expect(stack_prof).to receive(:start).with(
+        mode: :wall,
+        raw: true,
+        ignore_gc: true
+      )
+
+      described_class.profile
+    end
+
     specify "when block is given" do
       expect(stack_prof).to receive(:run).with(
         out: File.join(TestProf.config.output_dir, "stack-prof-report-wall-raw-stub.dump").to_s,


### PR DESCRIPTION
### What is the purpose of this pull request?

Add option `ignore_gc: true` when calling `StackProf.run` if `TEST_STACK_PROF_IGNORE_GC` is set.

As per StackProf README:
> By default, samples taken during garbage collection will show as garbage collection frames including both mark and sweep phases. For longer traces, these can leave gaps in a flamegraph that are hard to follow. They can be disabled by setting the `ignore_gc` option to true. Garbage collection time will still be present in the profile but not explicitly marked with its own frame.

### What changes did you make? (overview)

When `TEST_STACK_PROF_IGNORE_GC` env var is set, the `ignore_gc: true` option is added.

### Is there anything you'd like reviewers to focus on?

No

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
