### PR TITLE
FIX: event prof monitor methods with kwargs in Ruby 2.7+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix monitoring methods with keyword args in Ruby 3+. ([@palkan][])
+
 - Disable garbage collection frames when `TEST_STACK_PROF_IGNORE_GC` env variable is set ([@cbliard][])
 
 - Fixed restoring lock_thread value in nested contexts ([@ygelfand][])
@@ -299,3 +301,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@cou929]: https://github.com/cou929
 [@ruslanshakirov]: https://github.com/ruslanshakirov
 [@ygelfand]: https://github.com/ygelfand
+[@cbliard]: https://github.com/cbliard

--- a/lib/test_prof/event_prof/monitor.rb
+++ b/lib/test_prof/event_prof/monitor.rb
@@ -48,9 +48,16 @@ module TestProf
 
           patch = Module.new do
             mids.each do |mid|
-              define_method(mid) do |*args, &block|
-                next super(*args, &block) unless guard.nil? || instance_exec(*args, &guard)
-                tracker.track { super(*args, &block) }
+              if RUBY_VERSION >= "2.7.0"
+                define_method(mid) do |*args, **kwargs, &block|
+                  next super(*args, **kwargs, &block) unless guard.nil? || instance_exec(*args, **kwargs, &guard)
+                  tracker.track { super(*args, **kwargs, &block) }
+                end
+              else
+                define_method(mid) do |*args, &block|
+                  next super(*args, &block) unless guard.nil? || instance_exec(*args, &guard)
+                  tracker.track { super(*args, &block) }
+                end
               end
             end
           end

--- a/spec/integrations/fixtures/rspec/event_prof_monitor_fixture.rb
+++ b/spec/integrations/fixtures/rspec/event_prof_monitor_fixture.rb
@@ -14,8 +14,8 @@ class Work
     true
   end
 
-  def two
-    false
+  def two(flag: false)
+    flag
   end
 end
 
@@ -28,6 +28,6 @@ describe "Work" do
   end
 
   it "invokes twice" do
-    expect(w.one && w.two).to eq false
+    expect(w.two(flag: true) && w.two).to eq false
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix monitoring methods with kwargs in Ruby 3+.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation

