### PR TITLE
Factory Default improvements

### DIFF
--- a/.github/workflows/rspec-jruby.yml
+++ b/.github/workflows/rspec-jruby.yml
@@ -22,7 +22,7 @@ jobs:
           bundle-
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: jruby
+        ruby-version: jruby-9.3
     - name: Bundle install
       run: |
         bundle config path /home/runner/bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+- FactoryDefault: Allow creating a default per trait (or set of traits). ([@palkan][])
+
+Now `create_default(:user)` and `create_default(:user, :admin)` would result into two defaults corresponding to the specified traits.
+
 - FactoryDefault: Add stats support. ([@palkan][])
 
 Now you can see how often the default factory values have been used by specifying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## master (unreleased)
 
+- FactoryDefault: Add `preserve_attributes = false | true` option. ([@palkan][])
+
+Allow skipping defaults if association is defined with overrides, e.g.:
+
+```ruby
+factory :post do
+  association :user, name: "Post Author"
+end
+```
+
 - FactoryDefault: Add `skip_factory_default(&block)` to temporary disable default factories. ([@palkan][])
 
 You can also use `TestProf::FactoryDefault.disable!(&block)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add FactoryDefault profiler (factory associations profilers). ([@palkan][])
+
 - FactoryDefault: Allow creating a default per trait (or set of traits). ([@palkan][])
 
 Now `create_default(:user)` and `create_default(:user, :admin)` would result into two defaults corresponding to the specified traits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+- FactoryDefault: Add `skip_factory_default(&block)` to temporary disable default factories. ([@palkan][])
+
+You can also use `TestProf::FactoryDefault.disable!(&block)`.
+
 ## 1.0.11 (2022-10-27)
 
 - Fix monitoring methods with keyword args in Ruby 3+. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+- Support using FactoryDefault with before_all/let_it_be. ([@palkan][])
+
+Currently, RSpec only. Default factories created within `before_all` or `let_it_be` are not reset 'till the end of the corresponding context. Thus, now it's possible to use `create_default` within `let_it_be` without any additional hacks.
+
 - FactoryDefault: Add `preserve_attributes = false | true` option. ([@palkan][])
 
 Allow skipping defaults if association is defined with overrides, e.g.:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+- FactoryDefault: Add stats support. ([@palkan][])
+
+Now you can see how often the default factory values have been used by specifying
+the `FACTORY_DEFAULT_SUMMARY=1` or `FACTORY_DEFAULT_STATS=1` env var.
+
 - Support using FactoryDefault with before_all/let_it_be. ([@palkan][])
 
 Currently, RSpec only. Default factories created within `before_all` or `let_it_be` are not reset 'till the end of the corresponding context. Thus, now it's possible to use `create_default` within `let_it_be` without any additional hacks.

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -123,6 +123,10 @@ Defaults created within `before_all` and `let_it_be` are not reset after each ex
 You can use traits in your associations, for example:
 
 ```ruby
+factory :comment do
+  user
+end
+
 factory :post do
   association :user, factory: %i[user able_to_post]
 end
@@ -144,6 +148,20 @@ end
 
 # or in-place
 create_default(:user, preserve_traits: true)
+```
+
+Creating a default with trait works as follows:
+
+```ruby
+# Create a default with trait
+user = create_default(:user_poster, :able_to_post)
+
+# When an association has no traits specified, the default with trait is used
+create(:comment).user == user #=> true
+# When an association has the matching trait specified, the default is used, too
+create(:post).user == user #=> true
+# When the association's trait differs, default is skipped
+create(:view).user == user #=> false
 ```
 
 ### Handling attribute overrides

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -116,7 +116,7 @@ Defaults created within `before_all` and `let_it_be` are not reset after each ex
 
 **IMPORTANT:** You must load FactoryDefault after loading BeforeAll to make this feature work.
 
-**NOTE**. Regulart `before(:all)` callbacks are not supported.
+**NOTE**. Regular `before(:all)` callbacks are not supported.
 
 ### Working with traits
 
@@ -225,9 +225,9 @@ FactoryDefault summary: hit=11 miss=3
 
 Where `hit` indicates the number of times the default factory value was used instead of a new one when an association was created; `miss` indicates the number of time the default value was ignored due to traits or attributes mismatch.
 
-## Factory Default profiling, or when to use defaults?
+## Factory Default profiling, or when to use defaults
 
-Factory Default ships with the profiler, which can help you to see how associations are beeing used in your test suite, so you can decide on using `create_default` or not.
+Factory Default ships with the profiler, which can help you to see how associations are being used in your test suite, so you can decide on using `create_default` or not.
 
 To enable profiling, run your tests with the `FACTORY_DEFAULT_PROF=1` set:
 

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -224,3 +224,31 @@ FactoryDefault summary: hit=11 miss=3
 ```
 
 Where `hit` indicates the number of times the default factory value was used instead of a new one when an association was created; `miss` indicates the number of time the default value was ignored due to traits or attributes mismatch.
+
+## Factory Default profiling, or when to use defaults?
+
+Factory Default ships with the profiler, which can help you to see how associations are beeing used in your test suite, so you can decide on using `create_default` or not.
+
+To enable profiling, run your tests with the `FACTORY_DEFAULT_PROF=1` set:
+
+```sh
+$ FACTORY_DEFAULT_PROF=1 bundle exec rspec spec/some/file_spec.rb
+
+.....
+
+[TEST PROF INFO] Factory associations usage:
+
+               factory      count    total time
+
+                  user         17     00:42.010
+         user[traited]         15     00:31.560
+  user{tag:"some tag"}          1     00:00.205
+
+Total associations created: 33
+Total uniq associations created: 3
+Total time spent: 01:13.775
+```
+
+Since default factories are usually registered per an example group (or test class), we recommend running this profiler against a particular file, so you can quickly identify the possibility of adding `create_default` and improve the tests speed.
+
+**NOTE:** You can also use the profiler to measure the effect of adding `create_default`; for that, compare the results of running the profiler with FactoryDefault enabled and disabled (you can do that by passing the `FACTORY_DEFAULT_DISABLED=1` env var).

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -129,6 +129,32 @@ and set a default for `user` factory - you will find the same object used in all
 To prevent this - set `FactoryDefault.preserve_traits = true` or use per-factory override
 `create_default(:user, preserve_traits: true)`. This reverts back to original FactoryBot behavior for associations that have explicit traits defined.
 
+### Handling attribute overrides
+
+It's possible to define attribute overrides for associations:
+
+```ruby
+factory :post do
+  association :user, name: "Poster"
+end
+
+factory :view do
+  association :user, name: "Viewer"
+end
+```
+
+FactoryDefault ignores such overrides and still returns a default `user` record (if created). You can turn the attribute awareness feature on to skip the default record if overrides don't match the default object attributes:
+
+```ruby
+# Globally
+FactoryDefault.preserve_attributes = true
+
+# or in-place
+create_default :user, preserve_attributes: true
+```
+
+**NOTE:** In the future versions of Test Prof, both `preserve_traits` and `preserve_attributes` will default to true. We recommend settings them to true if you just starting using this feature.
+
 ### Ignoring default factories
 
 You can temporary disable the defaults usage by wrapping a code with the `skip_factory_default` method:

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -108,7 +108,15 @@ before { FactoryBot.set_factory_default(:user, user) }
 
 - `FactoryBot#create_default(factory, *args)` – is a shortcut for `create` + `set_factory_default`.
 
-**NOTE**. Defaults are **cleaned up after each example** by default. That means you cannot create defaults within `before(:all)` / [`before_all`](./before_all.md) / [`let_it_be`](./let_it_be.md) definitions. That could be changed in the future, for now [check this workaround](https://github.com/test-prof/test-prof/issues/125#issuecomment-471706752).
+**IMPORTANT:** Defaults are **cleaned up after each example** by default (i.e., when using `test_prof/recipes/rspec/factory_default`).
+
+### Using with `before_all` / `let_it_be`
+
+Defaults created within `before_all` and `let_it_be` are not reset after each example, but only at the end of the corresponding example group. So, it's possible to call `create_defatul` within `let_it_be` without any additional configuration. **RSpec only**
+
+**IMPORTANT:** You must load FactoryDefault after loading BeforeAll to make this feature work.
+
+**NOTE**. Regulart `before(:all)` callbacks are not supported.
 
 ### Working with traits
 

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -184,3 +184,25 @@ another_account = skip_factory_default { create(:account) }
 
 expect(another_account).not_to eq(account)
 ```
+
+### Showing usage stats
+
+You can display the FactoryDefault usage stats by setting the `FACTORY_DEFAULT_SUMMARY=1` or `FACTORY_DEFAULT_STATS=1` env vars or by setting the configuration values:
+
+```ruby
+TestProf::FactoryDefault.configure do |config|
+  config.report_summary = true
+  # Report stats prints the detailed usage information (including summary)
+  config.report_stats = true
+end
+```
+
+For example:
+
+```sh
+$ FACTORY_DEFAULT_SUMMARY=1 bundle exec rspec
+
+FactoryDefault summary: hit=11 miss=3
+```
+
+Where `hit` indicates the number of times the default factory value was used instead of a new one when an association was created; `miss` indicates the number of time the default value was ignored due to traits or attributes mismatch.

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -128,3 +128,14 @@ and set a default for `user` factory - you will find the same object used in all
 
 To prevent this - set `FactoryDefault.preserve_traits = true` or use per-factory override
 `create_default(:user, preserve_traits: true)`. This reverts back to original FactoryBot behavior for associations that have explicit traits defined.
+
+### Ignoring default factories
+
+You can temporary disable the defaults usage by wrapping a code with the `skip_factory_default` method:
+
+```ruby
+account = create_default(:account)
+another_account = skip_factory_default { create(:account) }
+
+expect(another_account).not_to eq(account)
+```

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -112,7 +112,7 @@ before { FactoryBot.set_factory_default(:user, user) }
 
 ### Working with traits
 
-When you have traits in your associations like:
+You can use traits in your associations, for example:
 
 ```ruby
 factory :post do
@@ -124,10 +124,19 @@ factory :view do
 end
 ```
 
-and set a default for `user` factory - you will find the same object used in all of the above factories. Sometimes this may break your logic.
+If there is a default value for the `user` factory, it's gonna be used independently of traits. This may break your logic.
 
-To prevent this - set `FactoryDefault.preserve_traits = true` or use per-factory override
-`create_default(:user, preserve_traits: true)`. This reverts back to original FactoryBot behavior for associations that have explicit traits defined.
+To prevent this, configure FactoryDefault to preserve traits:
+
+```ruby
+# Globally
+TestProf::FactoryDefault.configure do |config|
+  config.preserve_traits = true
+end
+
+# or in-place
+create_default(:user, preserve_traits: true)
+```
 
 ### Handling attribute overrides
 
@@ -147,7 +156,9 @@ FactoryDefault ignores such overrides and still returns a default `user` record 
 
 ```ruby
 # Globally
-FactoryDefault.preserve_attributes = true
+TestProf::FactoryDefault.configure do |config|
+  config.preserve_attributes = true
+end
 
 # or in-place
 create_default :user, preserve_attributes: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,19 @@
+pre-commit:
+  commands:
+    mdl:
+      tags: style
+      glob: "**/*.md"
+      exclude: ".github/*"
+      run: mdl {staged_files}
+    forspell:
+      tags: grammar
+      glob: "**/*.md"
+      run: forspell {staged_files}
+    rubocop:
+      tags: style
+      glob: "**/*.md"
+      run: bundle exec rubocop --force-exclusion {staged_files}
+    lychee:
+      tags: links
+      glob: "**/*.md"
+      run: lychee docs/*

--- a/lib/test_prof/before_all.rb
+++ b/lib/test_prof/before_all.rb
@@ -17,19 +17,19 @@ module TestProf
     class << self
       attr_accessor :adapter
 
-      def begin_transaction
+      def begin_transaction(scope = nil)
         raise AdapterMissing if adapter.nil?
 
-        config.run_hooks(:begin) do
+        config.run_hooks(:begin, scope) do
           adapter.begin_transaction
         end
         yield
       end
 
-      def rollback_transaction
+      def rollback_transaction(scope = nil)
         raise AdapterMissing if adapter.nil?
 
-        config.run_hooks(:rollback) do
+        config.run_hooks(:rollback, scope) do
           adapter.rollback_transaction
         end
       end
@@ -58,10 +58,10 @@ module TestProf
         @after = []
       end
 
-      def run
-        before.each(&:call)
+      def run(scope = nil)
+        before.each { |clbk| clbk.call(scope) }
         yield
-        after.each(&:call)
+        after.each { |clbk| clbk.call(scope) }
       end
     end
 
@@ -93,9 +93,9 @@ module TestProf
         hooks[type].after << block if block
       end
 
-      def run_hooks(type) # :nodoc:
+      def run_hooks(type, scope = nil) # :nodoc:
         validate_hook_type!(type)
-        hooks[type].run { yield }
+        hooks[type].run(scope) { yield }
       end
 
       private

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -19,7 +19,7 @@ module TestProf
         set_factory_default(name, obj, **default_options)
       end
 
-      def set_factory_default(name, obj, preserve_traits: FactoryDefault.preserve_traits, preserve_attributes: FactoryDefault.preserve_attributes)
+      def set_factory_default(name, obj, preserve_traits: FactoryDefault.config.preserve_traits, preserve_attributes: FactoryDefault.config.preserve_attributes)
         FactoryDefault.register(
           name, obj,
           preserve_traits: preserve_traits,
@@ -32,9 +32,17 @@ module TestProf
       end
     end
 
-    class << self
+    class Configuration
       attr_accessor :preserve_traits, :preserve_attributes
 
+      def initialize
+        # TODO(v2): Switch to true
+        @preserve_traits = false
+        @preserve_attributes = false
+      end
+    end
+
+    class << self
       def init
         TestProf::FactoryBot::Syntax::Methods.include DefaultSyntax
         TestProf::FactoryBot.extend DefaultSyntax
@@ -43,9 +51,23 @@ module TestProf
         TestProf::FactoryBot::Strategy::Stub.prepend StrategyExt
 
         @enabled = true
-        # default is false to retain backward compatibility
-        @preserve_traits = false
-        @preserve_attributes = false
+      end
+
+      def config
+        @config ||= Configuration.new
+      end
+
+      def configure
+        yield config
+      end
+
+      # TODO(v2): drop
+      def preserve_traits=(val)
+        config.preserve_traits = val
+      end
+
+      def preserve_attributes=(val)
+        config.preserve_attributes = val
       end
 
       def register(name, obj, **options)

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -43,6 +43,8 @@ module TestProf
     end
 
     class << self
+      attr_accessor :current_context
+
       def init
         TestProf::FactoryBot::Syntax::Methods.include DefaultSyntax
         TestProf::FactoryBot.extend DefaultSyntax
@@ -71,7 +73,7 @@ module TestProf
       end
 
       def register(name, obj, **options)
-        store[name] = {object: obj, **options}
+        store[name] = {object: obj, context: current_context, **options}
         obj
       end
 
@@ -101,8 +103,12 @@ module TestProf
         store.delete(name)
       end
 
-      def reset
-        store.clear
+      def reset(context: nil)
+        return store.clear unless context
+
+        store.delete_if do |_name, metadata|
+          metadata[:context] == context
+        end
       end
 
       def enabled?

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -11,14 +11,20 @@ module TestProf
     module DefaultSyntax # :nodoc:
       def create_default(name, *args, &block)
         options = args.extract_options!
-        preserve = options.delete(:preserve_traits)
+        default_options = {}
+        default_options[:preserve_traits] = options.delete(:preserve_traits) if options.key?(:preserve_traits)
+        default_options[:preserve_attributes] = options.delete(:preserve_attributes) if options.key?(:preserve_attributes)
 
         obj = TestProf::FactoryBot.create(name, *args, options, &block)
-        set_factory_default(name, obj, preserve_traits: preserve)
+        set_factory_default(name, obj, **default_options)
       end
 
-      def set_factory_default(name, obj, preserve_traits: nil)
-        FactoryDefault.register(name, obj, preserve_traits: preserve_traits)
+      def set_factory_default(name, obj, preserve_traits: FactoryDefault.preserve_traits, preserve_attributes: FactoryDefault.preserve_attributes)
+        FactoryDefault.register(
+          name, obj,
+          preserve_traits: preserve_traits,
+          preserve_attributes: preserve_attributes
+        )
       end
 
       def skip_factory_default(&block)
@@ -27,7 +33,7 @@ module TestProf
     end
 
     class << self
-      attr_accessor :preserve_traits
+      attr_accessor :preserve_traits, :preserve_attributes
 
       def init
         TestProf::FactoryBot::Syntax::Methods.include DefaultSyntax
@@ -39,24 +45,34 @@ module TestProf
         @enabled = true
         # default is false to retain backward compatibility
         @preserve_traits = false
+        @preserve_attributes = false
       end
 
       def register(name, obj, **options)
-        options[:preserve_traits] = true if FactoryDefault.preserve_traits
         store[name] = {object: obj, **options}
         obj
       end
 
-      def get(name, traits = nil)
+      def get(name, traits = nil, overrides = nil)
         return unless enabled?
 
         record = store[name]
         return unless record
 
         if traits && !traits.empty?
-          return if FactoryDefault.preserve_traits || record[:preserve_traits]
+          return if record[:preserve_traits]
         end
-        record[:object]
+
+        object = record[:object]
+
+        if overrides && !overrides.empty? && record[:preserve_attributes]
+          overrides.each do |name, value|
+            return unless object.respond_to?(name) # rubocop:disable Lint/NonLocalExitFromIterator
+            return if object.public_send(name) != value # rubocop:disable Lint/NonLocalExitFromIterator
+          end
+        end
+
+        object
       end
 
       def remove(name)

--- a/lib/test_prof/factory_default/factory_bot_patch.rb
+++ b/lib/test_prof/factory_default/factory_bot_patch.rb
@@ -4,13 +4,7 @@ module TestProf
   module FactoryDefault # :nodoc: all
     module RunnerExt
       refine TestProf::FactoryBot::FactoryRunner do
-        def name
-          @name
-        end
-
-        def traits
-          @traits
-        end
+        attr_reader :name, :traits, :overrides
       end
     end
 
@@ -18,7 +12,7 @@ module TestProf
 
     module StrategyExt
       def association(runner)
-        FactoryDefault.get(runner.name, runner.traits) || super
+        FactoryDefault.get(runner.name, runner.traits, runner.overrides) || super
       end
     end
   end

--- a/lib/test_prof/factory_default/factory_bot_patch.rb
+++ b/lib/test_prof/factory_default/factory_bot_patch.rb
@@ -12,7 +12,8 @@ module TestProf
 
     module StrategyExt
       def association(runner)
-        FactoryDefault.get(runner.name, runner.traits, runner.overrides) || super
+        FactoryDefault.get(runner.name, runner.traits, runner.overrides) ||
+          FactoryDefault.profiler.instrument(runner.name, runner.traits, runner.overrides) { super }
       end
     end
   end

--- a/lib/test_prof/factory_doctor/minitest.rb
+++ b/lib/test_prof/factory_doctor/minitest.rb
@@ -87,7 +87,7 @@ module Minitest
       private
 
       def pluralize_records(count)
-        count == 1 ? "1 record" : "#{count} records"
+        (count == 1) ? "1 record" : "#{count} records"
       end
     end
   end

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -18,7 +18,7 @@ module TestProf
       attr_accessor :mode, :printer
 
       def initialize
-        @mode = ENV["FPROF"] == "flamegraph" ? :flamegraph : :simple
+        @mode = (ENV["FPROF"] == "flamegraph") ? :flamegraph : :simple
         @printer =
           case ENV["FPROF"]
           when "flamegraph"

--- a/lib/test_prof/recipes/rspec/before_all.rb
+++ b/lib/test_prof/recipes/rspec/before_all.rb
@@ -17,23 +17,23 @@ module TestProf
           return
         end
 
-        @__before_all_activated__ = true
+        @__before_all_activation__ = context = self
 
         before(:all) do
           @__inspect_output = "before_all hook"
           BeforeAll.setup_fixtures(self) if setup_fixtures
-          BeforeAll.begin_transaction do
+          BeforeAll.begin_transaction(context) do
             instance_eval(&block)
           end
         end
 
         after(:all) do
-          BeforeAll.rollback_transaction
+          BeforeAll.rollback_transaction(context)
         end
       end
 
       def within_before_all?
-        instance_variable_defined?(:@__before_all_activated__)
+        instance_variable_defined?(:@__before_all_activation__)
       end
     end
   end

--- a/lib/test_prof/recipes/rspec/factory_default.rb
+++ b/lib/test_prof/recipes/rspec/factory_default.rb
@@ -4,6 +4,23 @@ require "test_prof/factory_default"
 
 TestProf::FactoryDefault.init
 
+if defined?(TestProf::BeforeAll)
+  TestProf::BeforeAll.configure do |config|
+    config.before(:begin) do |context|
+      TestProf::FactoryDefault.current_context = context
+    end
+
+    config.after(:rollback) do |context|
+      TestProf::FactoryDefault.reset(context: context)
+    end
+  end
+end
+
 RSpec.configure do |config|
-  config.after(:each) { TestProf::FactoryDefault.reset }
+  if defined?(TestProf::BeforeAll)
+    config.before(:each) { TestProf::FactoryDefault.current_context = :example }
+    config.after(:each) { TestProf::FactoryDefault.reset(context: :example) }
+  else
+    config.after(:each) { TestProf::FactoryDefault.reset }
+  end
 end

--- a/lib/test_prof/recipes/rspec/factory_default.rb
+++ b/lib/test_prof/recipes/rspec/factory_default.rb
@@ -23,4 +23,6 @@ RSpec.configure do |config|
   else
     config.after(:each) { TestProf::FactoryDefault.reset }
   end
+
+  config.after(:suite) { TestProf::FactoryDefault.print_report }
 end

--- a/lib/test_prof/recipes/rspec/let_it_be.rb
+++ b/lib/test_prof/recipes/rspec/let_it_be.rb
@@ -192,7 +192,7 @@ if defined?(::ActiveRecord::Base)
 
       next record.reload if record.is_a?(::ActiveRecord::Base)
 
-      if record.respond_to?(:map)
+      if record.respond_to?(:to_ary)
         next record.map do |rec|
           rec.is_a?(::ActiveRecord::Base) ? rec.reload : rec
         end
@@ -205,7 +205,7 @@ if defined?(::ActiveRecord::Base)
 
       next record.refind if record.is_a?(::ActiveRecord::Base)
 
-      if record.respond_to?(:map)
+      if record.respond_to?(:to_ary)
         next record.map do |rec|
           rec.is_a?(::ActiveRecord::Base) ? rec.refind : rec
         end

--- a/lib/test_prof/rspec_dissect.rb
+++ b/lib/test_prof/rspec_dissect.rb
@@ -47,7 +47,7 @@ module TestProf
         @let_top_count = (ENV["RD_PROF_LET_TOP"] || 3).to_i
         @top_count = (ENV["RD_PROF_TOP"] || 5).to_i
         @stamp = ENV["RD_PROF_STAMP"]
-        @mode = ENV["RD_PROF"] == "1" ? "all" : ENV["RD_PROF"]
+        @mode = (ENV["RD_PROF"] == "1") ? "all" : ENV["RD_PROF"]
 
         unless MODES.include?(mode)
           raise "Unknown RSpecDissect mode: #{mode};" \

--- a/lib/test_prof/stack_prof.rb
+++ b/lib/test_prof/stack_prof.rb
@@ -27,7 +27,7 @@ module TestProf
       attr_accessor :mode, :raw, :target, :format, :interval, :ignore_gc
       def initialize
         @mode = ENV.fetch("TEST_STACK_PROF_MODE", :wall).to_sym
-        @target = ENV["TEST_STACK_PROF"] == "boot" ? :boot : :suite
+        @target = (ENV["TEST_STACK_PROF"] == "boot") ? :boot : :suite
         @raw = ENV["TEST_STACK_PROF_RAW"] != "0"
         @format =
           if FORMATS.include?(ENV["TEST_STACK_PROF_FORMAT"])
@@ -37,7 +37,7 @@ module TestProf
           end
 
         sample_interval = ENV["TEST_STACK_PROF_INTERVAL"].to_i
-        @interval = sample_interval > 0 ? sample_interval : nil
+        @interval = (sample_interval > 0) ? sample_interval : nil
         @ignore_gc = !ENV["TEST_STACK_PROF_IGNORE_GC"].nil?
       end
 

--- a/lib/test_prof/tag_prof/rspec.rb
+++ b/lib/test_prof/tag_prof/rspec.rb
@@ -13,7 +13,7 @@ module TestProf
       attr_reader :result, :printer
 
       def initialize
-        @printer = ENV["TAG_PROF_FORMAT"] == "html" ? Printers::HTML : Printers::Simple
+        @printer = (ENV["TAG_PROF_FORMAT"] == "html") ? Printers::HTML : Printers::Simple
 
         @result =
           if ENV["TAG_PROF_EVENT"].nil?

--- a/spec/integrations/factory_default_spec.rb
+++ b/spec/integrations/factory_default_spec.rb
@@ -6,4 +6,10 @@ describe "FactoryDefault" do
 
     expect(output).to include("0 failures")
   end
+
+  specify "let_it_be integration", :aggregate_failures do
+    output = run_rspec("factory_default_let_it_be")
+
+    expect(output).to include("0 failures")
+  end
 end

--- a/spec/integrations/factory_default_spec.rb
+++ b/spec/integrations/factory_default_spec.rb
@@ -1,15 +1,48 @@
 # frozen_string_literal: true
 
-describe "FactoryDefault" do
-  specify "RSpec integration", :aggregate_failures do
-    output = run_rspec("factory_default")
+describe "FactoryDefault", :aggregate_failures do
+  context "RSpec integration" do
+    specify "basic" do
+      output = run_rspec("factory_default")
 
-    expect(output).to include("0 failures")
-  end
+      expect(output).to include("0 failures")
+    end
 
-  specify "let_it_be integration", :aggregate_failures do
-    output = run_rspec("factory_default_let_it_be")
+    specify "let_it_be integration" do
+      output = run_rspec("factory_default_let_it_be")
 
-    expect(output).to include("0 failures")
+      expect(output).to include("0 failures")
+    end
+
+    specify "stats" do
+      output = run_rspec("factory_default", env: {"FACTORY_DEFAULT_STATS" => "1"})
+
+      expect(output).to include("0 failures")
+
+      expect(output).to include("FactoryDefault summary: hit=11 miss=3")
+      expect(output).to match(/factory\s+hit\s+miss\n\n/)
+      expect(output).to match(/user\s+11\s+3/)
+    end
+
+    specify "analyze" do
+      output = run_rspec(
+        "factory_default_analyze",
+        env: {
+          "FACTORY_DEFAULT_PROF" => "1"
+        }
+      )
+
+      expect(output).to include("0 failures")
+
+      expect(output).to include("Factory associations usage:")
+      expect(output).to match(/factory\s+count\s+total time\n\n/)
+      expect(output).to match(/user\s+7\s+\d{2}:\d{2}\.\d{3}/)
+      expect(output).to match(/user\[traited\]\s+1\s+\d{2}:\d{2}\.\d{3}/)
+      expect(output).to match(/user\{tag:"some tag"\}\s+1\s+\d{2}:\d{2}\.\d{3}/)
+      expect(output).to include("Total associations created: 9")
+      expect(output).to include("Total uniq associations created: 3")
+      expect(output).to match(/Total time spent: \d{2}:\d{2}\.\d{3}/)
+      expect(output).to include("0 failures")
+    end
   end
 end

--- a/spec/integrations/fixtures/rspec/factory_default_analyze_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_default_analyze_fixture.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require_relative "../../../support/ar_models"
+require_relative "../../../support/transactional_context"
+require "test_prof/recipes/rspec/factory_default"
+
+describe "Post" do
+  let(:user) { TestProf::FactoryBot.create(:user) }
+  let(:post) { TestProf::FactoryBot.create(:post) }
+
+  it "creates post with different user" do
+    user
+    expect { post }.to change(User, :count)
+    expect(post.user).not_to eq user
+  end
+
+  it "creates user if no default" do
+    expect { post }.to change(User, :count).by(1)
+  end
+
+  it "creates many records" do
+    user
+    expect { TestProf::FactoryBot.create_list(:post, 5) }.to change(User, :count).by(5)
+  end
+
+  context "with traits" do
+    let(:post) { TestProf::FactoryBot.create(:post, :with_traited_user) }
+
+    it "can still be set default" do
+      expect(post.user.tag).to eq "traited"
+    end
+  end
+
+  context "with overrides" do
+    let(:post) { TestProf::FactoryBot.create(:post, :with_tagged_user) }
+
+    it "can still be set default" do
+      expect(post.user.tag).to eq "some tag"
+    end
+  end
+end

--- a/spec/integrations/fixtures/rspec/factory_default_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_default_fixture.rb
@@ -47,7 +47,11 @@ describe "Post" do
     let(:traited_user) { TestProf::FactoryBot.create_default(:user, :traited, tag: "foo") }
 
     context "global setting" do
-      before { TestProf::FactoryDefault.preserve_traits = true }
+      before do
+        TestProf::FactoryDefault.configure do |config|
+          config.preserve_traits = true
+        end
+      end
 
       it "can still be set default" do
         expect(traited_user.tag).to eq "foo"
@@ -66,7 +70,12 @@ describe "Post" do
     end
 
     context "local override" do
-      before { TestProf::FactoryDefault.preserve_traits = false }
+      before do
+        TestProf::FactoryDefault.configure do |config|
+          config.preserve_traits = false
+        end
+      end
+
       let(:override_user) { TestProf::FactoryBot.create_default(:user, preserve_traits: true) }
       let(:other_traited_post) { TestProf::FactoryBot.create(:post, :with_traited_user) }
 

--- a/spec/integrations/fixtures/rspec/factory_default_let_it_be_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_default_let_it_be_fixture.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require_relative "../../../support/ar_models"
+require_relative "../../../support/transactional_context"
+
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/factory_default"
+
+describe "Post" do
+  let(:post) { TestProf::FactoryBot.create(:post) }
+
+  context "with let_it_be" do
+    let_it_be(:user) { TestProf::FactoryBot.create_default(:user) }
+
+    it "creates post with the same user" do
+      user
+      expect { post }.not_to change(User, :count)
+      expect(post.user).to eq user
+    end
+
+    it "still uses the default from let_it_be" do
+      expect { post }.not_to change(User, :count)
+    end
+
+    context "when nested" do
+      let_it_be(:post) { TestProf::FactoryBot.create_default(:post) }
+
+      it "still uses the default from let_it_be" do
+        expect { post }.not_to change(User, :count)
+      end
+
+      it "default is used within let_it_be" do
+        expect(post.user).to eq user
+      end
+    end
+  end
+
+  context "without let_it_be" do
+    it "creates a new record" do
+      expect { post }.to change(User, :count).by(1)
+    end
+  end
+end

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -110,6 +110,10 @@ TestProf::FactoryBot.define do
       user { create(:user) }
     end
 
+    trait :with_tagged_user do
+      association :user, tag: "some tag"
+    end
+
     trait :with_traited_user do
       association :user, factory: %i[user traited]
     end

--- a/spec/test_prof/factory_default_spec.rb
+++ b/spec/test_prof/factory_default_spec.rb
@@ -56,6 +56,18 @@ describe TestProf::FactoryDefault, :transactional do
       expect(post.user).to eq user
       expect(post_traited.user).not_to eq user
     end
+
+    context "when has default with the trait" do
+      let!(:traited_user) { TestProf::FactoryBot.create_default(:user, :traited) }
+
+      it "re-uses default record for this trait" do
+        post = TestProf::FactoryBot.create_default(:post)
+        post_traited = TestProf::FactoryBot.create(:post, :with_traited_user)
+
+        expect(post.user).to eq user
+        expect(post_traited.user).to eq traited_user
+      end
+    end
   end
 
   context "when preserve_attributes = true" do

--- a/spec/test_prof/factory_default_spec.rb
+++ b/spec/test_prof/factory_default_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Init FactoryDefault
+require "test_prof/factory_default"
+
+TestProf::FactoryDefault.init
+TestProf::FactoryDefault.disable!
+
+describe TestProf::FactoryDefault, :transactional do
+  before { described_class.enable! }
+  after do
+    described_class.reset
+    described_class.disable!
+  end
+
+  let!(:user) { TestProf::FactoryBot.create_default(:user) }
+
+  it "re-uses the same default record" do
+    post = TestProf::FactoryBot.create(:post)
+
+    expect(post.user).to eq user
+  end
+
+  it "re-uses default record independently of traits" do
+    post = TestProf::FactoryBot.create(:post, :with_traited_user)
+
+    expect(post.user).to eq user
+  end
+
+  it "re-uses default record independently of attributes" do
+    post = TestProf::FactoryBot.create(:post, :with_tagged_user)
+
+    expect(post.user).to eq user
+  end
+
+  specify ".disable!(&block)" do
+    post = TestProf::FactoryBot.skip_factory_default { TestProf::FactoryBot.create(:post) }
+    expect(post.user).not_to eq(user)
+  end
+
+  context "when preserve_traits = true" do
+    before { described_class.preserve_traits = true }
+    after { described_class.preserve_traits = false }
+
+    it "ignores default when trait is specified" do
+      post = TestProf::FactoryBot.create_default(:post)
+      post_traited = TestProf::FactoryBot.create(:post, :with_traited_user)
+
+      expect(post.user).to eq user
+      expect(post_traited.user).not_to eq user
+    end
+  end
+
+  xcontext "when preserve_attributes = true" do
+    before { described_class.preserve_attributes = true }
+    after { described_class.preserve_attributes = false }
+
+    it "ignores default when explicit attributes don't match" do
+      post = TestProf::FactoryBot.create_default(:post)
+      user_2 = TestProf::FactoryBot.create(:user, tag: "another")
+      post_2 = TestProf::FactoryBot.create(:post, user: user_2)
+
+      expect(post.user).to eq user
+      expect(post_2.user).to eq user_2
+      expect(post_2).not_to eq post
+    end
+
+    it "re-uses default when attributes match" do
+      post = TestProf::FactoryBot.create_default(:post, text: "Test")
+      post_2 = TestProf::FactoryBot.create(:post, text: "Test")
+
+      expect(post_2).to eq post
+    end
+  end
+end

--- a/spec/test_prof/factory_default_spec.rb
+++ b/spec/test_prof/factory_default_spec.rb
@@ -7,7 +7,15 @@ TestProf::FactoryDefault.init
 TestProf::FactoryDefault.disable!
 
 describe TestProf::FactoryDefault, :transactional do
-  before { described_class.enable! }
+  let(:preserve_traits) { false }
+  let(:preserve_attributes) { false }
+
+  before do
+    described_class.enable!
+    described_class.preserve_traits = preserve_traits
+    described_class.preserve_attributes = preserve_attributes
+  end
+
   after do
     described_class.reset
     described_class.disable!
@@ -39,8 +47,7 @@ describe TestProf::FactoryDefault, :transactional do
   end
 
   context "when preserve_traits = true" do
-    before { described_class.preserve_traits = true }
-    after { described_class.preserve_traits = false }
+    let(:preserve_traits) { true }
 
     it "ignores default when trait is specified" do
       post = TestProf::FactoryBot.create_default(:post)
@@ -51,25 +58,21 @@ describe TestProf::FactoryDefault, :transactional do
     end
   end
 
-  xcontext "when preserve_attributes = true" do
-    before { described_class.preserve_attributes = true }
-    after { described_class.preserve_attributes = false }
+  context "when preserve_attributes = true" do
+    let(:preserve_attributes) { true }
 
     it "ignores default when explicit attributes don't match" do
-      post = TestProf::FactoryBot.create_default(:post)
-      user_2 = TestProf::FactoryBot.create(:user, tag: "another")
-      post_2 = TestProf::FactoryBot.create(:post, user: user_2)
+      post = TestProf::FactoryBot.create(:post, :with_tagged_user)
 
-      expect(post.user).to eq user
-      expect(post_2.user).to eq user_2
-      expect(post_2).not_to eq post
+      expect(post.user).not_to eq user
     end
 
     it "re-uses default when attributes match" do
-      post = TestProf::FactoryBot.create_default(:post, text: "Test")
-      post_2 = TestProf::FactoryBot.create(:post, text: "Test")
+      user.update!(tag: "some tag")
 
-      expect(post_2).to eq post
+      post = TestProf::FactoryBot.create(:post, :with_tagged_user)
+
+      expect(post.user).to eq user
     end
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

Multiple improvements to FactoryDefault.

### What changes did you make? (overview)

- [x] Handle association overrides (e.g., `association :user, role: :admin`) -> `FactoryDefault.preserve_attributes = false | true`
- [x] Make FactoryDefault compatible with `let_it_be` / `before_all` (RSpec only for now)
  - Context defaults are reset at the end of the context
  - Associations created with `let_it_be` are automatically _refinded_.  
- [x] Added support for per-trait defaults 
- [x] Added usage statistics (how many times a default was hit or missed)
- [x] Added FactoryDefault profiler to analyze associations usage (so you can decide where to add the default).

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

