### PR TITLE
Add support for multiple databases to BeforeAll ActiveRecord adapter

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -22,9 +22,11 @@ jobs:
         - ruby: 3.1
           gemfile: "gemfiles/activerecord7.gemfile"
           db: "sqlite"
+          multi_db: "true"
         - ruby: 3.1
           gemfile: "gemfiles/activerecord7.gemfile"
           db: "postgres"
+          multi_db: "true"
         - ruby: 3.0
           gemfile: "gemfiles/activerecord6.gemfile"
           db: "sqlite"
@@ -75,6 +77,7 @@ jobs:
     - name: Run RSpec
       env:
           DB: ${{ matrix.db }}
+          MULTI_DB: ${{ matrix.multi_db }}
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           DB_NAME: postgres
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add support for ActiveRecord multiple databases ([@rutgerw][])
+
 ## 1.1.0 (2022-12-06)
 
 - LetItBe: freeze records during initialization with `freeze: true`. ([@palkan][])

--- a/docs/recipes/before_all.md
+++ b/docs/recipes/before_all.md
@@ -59,6 +59,36 @@ Make sure to check the [Caveats section](#caveats) of this document for details.
 
 ## Instructions
 
+### Multiple database support
+
+The ActiveRecord BeforeAll adapter will only start a transaction using ActiveRecord::Base connection.
+If you want to ensure `before_all` can use multiple connections, you need to ensure the connection
+classes are loaded before using `before_all`.
+
+For example, imagine you have `ApplicationRecord` and a separate database for user accounts:
+
+```ruby
+class Users < AccountsRecord
+
+end
+
+class Articles < ApplicationRecord
+
+end
+```
+
+Then those two Connection Classes do need to be loaded before the tests are run:
+
+```ruby
+
+# Ensure connection classes are loaded
+ApplicationRecord
+AccountsRecord
+```
+
+This code can be added to `rails_helper.rb` or the rake tasks thats runs minitests.
+
+
 ### RSpec
 
 In your `rails_helper.rb` (or `spec_helper.rb` after *ActiveRecord* has been loaded):

--- a/docs/recipes/before_all.md
+++ b/docs/recipes/before_all.md
@@ -88,7 +88,6 @@ AccountsRecord
 
 This code can be added to `rails_helper.rb` or the rake tasks thats runs minitests.
 
-
 ### RSpec
 
 In your `rails_helper.rb` (or `spec_helper.rb` after *ActiveRecord* has been loaded):

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -7,7 +7,11 @@ module TestProf
       module ActiveRecord
         class << self
           def all_connections
-            @all_connections ||= ::ActiveRecord::Base.connection_handler.connection_pool_list(:writing).map(&:connection)
+            @all_connections ||= if ::ActiveRecord::Base.respond_to? :connects_to
+              ::ActiveRecord::Base.connection_handler.connection_pool_list(:writing).map(&:connection)
+            else
+              Array.wrap(::ActiveRecord::Base.connection)
+            end
           end
 
           def begin_transaction

--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -15,6 +15,7 @@ module TestProf
           end
 
           def begin_transaction
+            @all_connections = nil
             all_connections.each do |connection|
               connection.begin_transaction(joinable: false)
             end

--- a/spec/integrations/fixtures/rspec/before_all_isolator_fixture.rb
+++ b/spec/integrations/fixtures/rspec/before_all_isolator_fixture.rb
@@ -28,7 +28,7 @@ class FailingJob
   end
 end
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   attr_accessor :commited
 end
 

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -14,6 +14,7 @@ rescue LoadError
 end
 
 def multi_db?
+  return false unless ActiveRecord::Base.respond_to? :connects_to
   return false unless ENV["MULTI_DB"]
 
   ENV["MULTI_DB"] == "true"
@@ -56,6 +57,11 @@ if multi_db?
 
     connects_to database: {writing: :comments, reading: :comments}
   end
+
+  class Comment < CommentsRecord
+    belongs_to :user, dependent: :destroy
+  end
+
   CommentsRecord.establish_connection
 else
   ActiveRecord::Base.configurations = {default_env: DB_CONFIG}
@@ -63,7 +69,8 @@ else
     self.abstract_class = true
   end
 
-  class CommentsRecord < ApplicationRecord
+  class Comment < ApplicationRecord
+    belongs_to :user, dependent: :destroy
   end
 end
 
@@ -125,10 +132,6 @@ class Post < ApplicationRecord
   belongs_to :user
 
   attr_accessor :dirty
-end
-
-class Comment < CommentsRecord
-  belongs_to :user, dependent: :destroy
 end
 
 TestProf::FactoryBot.define do

--- a/spec/test_prof/before_all/adapters/active_record_spec.rb
+++ b/spec/test_prof/before_all/adapters/active_record_spec.rb
@@ -9,55 +9,97 @@ end
 
 require "test_prof/before_all/adapters/active_record"
 
-describe "TestProf::BeforeAll::Adapters::ActiveRecord" do
-  let(:connection_pool_list) { [ActiveRecord::Base, ActiveRecord::Base.clone] }
-  let(:connection_1) { connection_pool_list.first.connection }
-  let(:connection_2) { connection_pool_list.second.connection }
+describe TestProf::BeforeAll::Adapters::ActiveRecord do
+  context "when using single database", skip: (multi_db? ? "Using multiple databases" : nil) do
+    let(:connection_pool) { ApplicationRecord }
+    let(:connection) { connection_pool.connection }
 
-  before do
-    allow(::ActiveRecord::Base.connection_handler).to receive(:connection_pool_list).with(:writing).and_return(connection_pool_list)
-  end
+    describe ".begin_transaction" do
+      subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.begin_transaction }
 
-  describe ".begin_transaction" do
-    subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.begin_transaction }
-
-    it "calls begin_transaction on all available connections" do
-      expect(connection_1).to receive(:begin_transaction).with(joinable: false)
-      expect(connection_2).to receive(:begin_transaction).with(joinable: false)
-
-      subject
-    end
-  end
-
-  describe ".rollback_transaction" do
-    subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.rollback_transaction }
-
-    context "when not all connections have started a transaction" do
-      before do
-        # Ensure no transactions are open due to randomization of specs
-        connection_1.rollback_transaction unless connection_1.open_transactions.zero?
-        connection_2.rollback_transaction unless connection_2.open_transactions.zero?
-        connection_2.begin_transaction
-      end
-
-      it "warns when connection does not have open transaction" do
-        expect { subject }.to output(
-          "!!! before_all transaction has been already rollbacked and could work incorrectly\n"
-        ).to_stderr
-      end
-    end
-
-    context "when the connection is a transaction" do
-      before do
-        connection_1.begin_transaction
-        connection_2.begin_transaction
-      end
-
-      it "calls rollback_transaction on all available connections" do
-        expect(connection_1).to receive(:rollback_transaction)
-        expect(connection_2).to receive(:rollback_transaction)
+      it "calls begin_transaction on all available connections" do
+        expect(connection).to receive(:begin_transaction).with(joinable: false)
 
         subject
+      end
+    end
+
+    describe ".rollback_transaction" do
+      subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.rollback_transaction }
+
+      context "when not all connections have started a transaction" do
+        before do
+          # Ensure no transactions are open due to randomization of specs
+          connection.rollback_transaction unless connection.open_transactions.zero?
+        end
+
+        it "warns when connection does not have open transaction" do
+          expect { subject }.to output(
+            "!!! before_all transaction has been already rollbacked and could work incorrectly\n"
+          ).to_stderr
+        end
+      end
+
+      context "when the connection is a transaction" do
+        before do
+          connection.begin_transaction
+        end
+
+        it "calls rollback_transaction on all available connections" do
+          expect(connection).to receive(:rollback_transaction)
+
+          subject
+        end
+      end
+    end
+  end
+
+  context "when using multiple databases", skip: ((!multi_db?) ? "Using single database" : nil) do
+    let(:connection_pool_list) { [ApplicationRecord, CommentsRecord] }
+    let(:connection_1) { connection_pool_list.first.connection }
+    let(:connection_2) { connection_pool_list.second.connection }
+
+    describe ".begin_transaction" do
+      subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.begin_transaction }
+
+      it "calls begin_transaction on all available connections" do
+        expect(connection_1).to receive(:begin_transaction).with(joinable: false)
+        expect(connection_2).to receive(:begin_transaction).with(joinable: false)
+
+        subject
+      end
+    end
+
+    describe ".rollback_transaction" do
+      subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.rollback_transaction }
+
+      context "when not all connections have started a transaction" do
+        before do
+          # Ensure no transactions are open due to randomization of specs
+          connection_1.rollback_transaction unless connection_1.open_transactions.zero?
+          connection_2.rollback_transaction unless connection_2.open_transactions.zero?
+          connection_2.begin_transaction
+        end
+
+        it "warns when connection does not have open transaction" do
+          expect { subject }.to output(
+            "!!! before_all transaction has been already rollbacked and could work incorrectly\n"
+          ).to_stderr
+        end
+      end
+
+      context "when the connection is a transaction" do
+        before do
+          connection_1.begin_transaction
+          connection_2.begin_transaction
+        end
+
+        it "calls rollback_transaction on all available connections" do
+          expect(connection_1).to receive(:rollback_transaction)
+          expect(connection_2).to receive(:rollback_transaction)
+
+          subject
+        end
       end
     end
   end

--- a/spec/test_prof/before_all/adapters/active_record_spec.rb
+++ b/spec/test_prof/before_all/adapters/active_record_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module TestProf
+  module BeforeAll
+    def self.configure
+    end
+  end
+end
+
+require "test_prof/before_all/adapters/active_record"
+
+describe "TestProf::BeforeAll::Adapters::ActiveRecord" do
+  let(:connection_class_1) { ActiveRecord::Base }
+  let(:connection_1) { connection_class_1.connection }
+
+  let(:connection_class_2) { ActiveRecord::Base }
+  let(:connection_2) { connection_class_2.connection }
+
+  before do
+    allow(ActiveRecord::Base).to receive(:descendants).and_return([connection_class_2])
+
+    allow(connection_class_2).to receive(:connection_class?).and_return(true)
+    allow(connection_class_2).to receive(:connection).and_return(connection_2)
+  end
+
+  describe ".begin_transaction" do
+    subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.begin_transaction }
+
+    it "calls begin_transaction on all available connections" do
+      expect(connection_1).to receive(:begin_transaction).with(joinable: false)
+      expect(connection_2).to receive(:begin_transaction).with(joinable: false)
+
+      subject
+    end
+  end
+
+  describe ".rollback_transaction" do
+    subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.rollback_transaction }
+
+    context "when not all connections have started a transaction" do
+      before do
+        # Ensure no transactions are open due to randomization of specs
+        connection_1.rollback_transaction unless connection_1.open_transactions.zero?
+        connection_2.rollback_transaction unless connection_2.open_transactions.zero?
+        connection_2.begin_transaction
+      end
+
+      it "warns when connection does not have open transaction" do
+        expect { subject }.to output(
+          "!!! before_all transaction has been already rollbacked and could work incorrectly\n"
+        ).to_stderr
+      end
+    end
+
+    context "when the connection is a transaction" do
+      before do
+        connection_1.begin_transaction
+        connection_2.begin_transaction
+      end
+
+      it "calls rollback_transaction on all available connections" do
+        expect(connection_1).to receive(:rollback_transaction)
+        expect(connection_2).to receive(:rollback_transaction)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/test_prof/before_all/adapters/active_record_spec.rb
+++ b/spec/test_prof/before_all/adapters/active_record_spec.rb
@@ -10,17 +10,12 @@ end
 require "test_prof/before_all/adapters/active_record"
 
 describe "TestProf::BeforeAll::Adapters::ActiveRecord" do
-  let(:connection_class_1) { ActiveRecord::Base }
-  let(:connection_1) { connection_class_1.connection }
-
-  let(:connection_class_2) { ActiveRecord::Base }
-  let(:connection_2) { connection_class_2.connection }
+  let(:connection_pool_list) { [ActiveRecord::Base, ActiveRecord::Base.clone] }
+  let(:connection_1) { connection_pool_list.first.connection }
+  let(:connection_2) { connection_pool_list.second.connection }
 
   before do
-    allow(ActiveRecord::Base).to receive(:descendants).and_return([connection_class_2])
-
-    allow(connection_class_2).to receive(:connection_class?).and_return(true)
-    allow(connection_class_2).to receive(:connection).and_return(connection_2)
+    allow(::ActiveRecord::Base.connection_handler).to receive(:connection_pool_list).with(:writing).and_return(connection_pool_list)
   end
 
   describe ".begin_transaction" do


### PR DESCRIPTION
### What is the purpose of this pull request?

Add support for ActiveRecord multiple databases

### What changes did you make? (overview)

- The `BeforeAll` ActiveRecord adapter will now call `begin_transaction` on all descendants of ActiveRecord::Base.
- Added specs for the adapter class

### Checklist

- [X] I've added tests for this change
- [x] I've added a Changelog entry
- [X] I've updated a documentation
