### PR TITLE
Add FactoryBot.get_factory_default

### DIFF
--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -94,9 +94,9 @@ In your `spec_helper.rb`:
 require "test_prof/recipes/rspec/factory_default"
 ```
 
-This adds three new methods to FactoryBot:
+This adds the following methods to FactoryBot:
 
-- `FactoryBot#set_factory_default(factory, object)` – use the `object` as default for associations built with `factory`
+- `FactoryBot#set_factory_default(factory, object)` – use the `object` as default for associations built with `factory`.
 
 Example:
 
@@ -104,11 +104,22 @@ Example:
 let(:user) { create(:user) }
 
 before { FactoryBot.set_factory_default(:user, user) }
+
+# You can also set the default factory with traits
+FactoryBot.set_factory_default([:user, :amdin], admin)
+
+# Or (since v1.4)
+FactoryBot.set_factory_default(:user, :amdin, admin)
 ```
 
-- `FactoryBot#create_default(factory, *args)` – is a shortcut for `create` + `set_factory_default`.
+- `FactoryBot#create_default(...)` – is a shortcut for `create` + `set_factory_default`.
 
-- `FactoryBot#get_factory_default(factory, *args)` – retrieves the default value for `factory`
+- `FactoryBot#get_factory_default(factory)` – retrieves the default value for `factory` (since v1.4).
+
+```rb
+# This method also supports traits
+admin = FactoryBot.get_factory_default(:user, :amdin)
+```
 
 **IMPORTANT:** Defaults are **cleaned up after each example** by default (i.e., when using `test_prof/recipes/rspec/factory_default`).
 

--- a/docs/recipes/factory_default.md
+++ b/docs/recipes/factory_default.md
@@ -94,7 +94,7 @@ In your `spec_helper.rb`:
 require "test_prof/recipes/rspec/factory_default"
 ```
 
-This adds two new methods to FactoryBot:
+This adds three new methods to FactoryBot:
 
 - `FactoryBot#set_factory_default(factory, object)` – use the `object` as default for associations built with `factory`
 
@@ -107,6 +107,8 @@ before { FactoryBot.set_factory_default(:user, user) }
 ```
 
 - `FactoryBot#create_default(factory, *args)` – is a shortcut for `create` + `set_factory_default`.
+
+- `FactoryBot#get_factory_default(factory, *args)` – retrieves the default value for `factory`
 
 **IMPORTANT:** Defaults are **cleaned up after each example** by default (i.e., when using `test_prof/recipes/rspec/factory_default`).
 

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -168,6 +168,10 @@ module TestProf
         )
       end
 
+      def get_factory_default(name, *args)
+        FactoryDefault.get(name, traits = args, overrides = args.extract_options!, write_stats = false)
+      end
+
       def skip_factory_default(&block)
         FactoryDefault.disable!(&block)
       end
@@ -236,7 +240,7 @@ module TestProf
         obj
       end
 
-      def get(name, traits = nil, overrides = nil)
+      def get(name, traits = nil, overrides = nil, write_stats = true)
         return unless enabled?
 
         record = store[name]
@@ -248,7 +252,7 @@ module TestProf
           traits = nil
         end
 
-        stats[name][:miss] += 1
+        stats[name][:miss] += 1 if write_stats
 
         if traits && !traits.empty? && record[:preserve_traits]
           return
@@ -263,8 +267,10 @@ module TestProf
           end
         end
 
-        stats[name][:miss] -= 1
-        stats[name][:hit] += 1
+        if write_stats
+            stats[name][:miss] -= 1
+            stats[name][:hit] += 1
+        end
 
         if record[:context] && (record[:context] != :example)
           object.refind

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -169,7 +169,7 @@ module TestProf
       end
 
       def get_factory_default(name, *args)
-        FactoryDefault.get(name, traits = args, overrides = args.extract_options!, write_stats = false)
+        FactoryDefault.get(name, args, args.extract_options!, false)
       end
 
       def skip_factory_default(&block)
@@ -268,8 +268,8 @@ module TestProf
         end
 
         if write_stats
-            stats[name][:miss] -= 1
-            stats[name][:hit] += 1
+          stats[name][:miss] -= 1
+          stats[name][:hit] += 1
         end
 
         if record[:context] && (record[:context] != :example)

--- a/lib/test_prof/factory_default.rb
+++ b/lib/test_prof/factory_default.rb
@@ -159,7 +159,8 @@ module TestProf
         set_factory_default(name, obj, **default_options)
       end
 
-      def set_factory_default(name, obj, preserve_traits: FactoryDefault.config.preserve_traits, preserve_attributes: FactoryDefault.config.preserve_attributes, **other)
+      def set_factory_default(*name, obj, preserve_traits: FactoryDefault.config.preserve_traits, preserve_attributes: FactoryDefault.config.preserve_attributes, **other)
+        name = name.first if name.size == 1
         FactoryDefault.register(
           name, obj,
           preserve_traits: preserve_traits,
@@ -168,8 +169,8 @@ module TestProf
         )
       end
 
-      def get_factory_default(name, *args)
-        FactoryDefault.get(name, args, args.extract_options!, false)
+      def get_factory_default(name, *traits, **overrides)
+        FactoryDefault.get(name, traits, overrides, skip_stats: true)
       end
 
       def skip_factory_default(&block)
@@ -240,7 +241,7 @@ module TestProf
         obj
       end
 
-      def get(name, traits = nil, overrides = nil, write_stats = true)
+      def get(name, traits = nil, overrides = nil, skip_stats: false)
         return unless enabled?
 
         record = store[name]
@@ -252,7 +253,7 @@ module TestProf
           traits = nil
         end
 
-        stats[name][:miss] += 1 if write_stats
+        stats[name][:miss] += 1 unless skip_stats
 
         if traits && !traits.empty? && record[:preserve_traits]
           return
@@ -267,7 +268,7 @@ module TestProf
           end
         end
 
-        if write_stats
+        unless skip_stats
           stats[name][:miss] -= 1
           stats[name][:hit] += 1
         end

--- a/spec/test_prof/factory_default_spec.rb
+++ b/spec/test_prof/factory_default_spec.rb
@@ -35,6 +35,7 @@ describe TestProf::FactoryDefault, :transactional do
 
     expect(TestProf::FactoryBot.get_factory_default(:user)).to eq user
     expect(post.user).to eq user
+    expect(TestProf::FactoryBot.get_factory_default(:user, :traited)).to eq user
   end
 
   it "re-uses default record independently of attributes" do
@@ -67,7 +68,10 @@ describe TestProf::FactoryDefault, :transactional do
     end
 
     context "when has default with the trait" do
-      let!(:traited_user) { TestProf::FactoryBot.create_default(:user, :traited) }
+      let!(:traited_user) do
+        user = TestProf::FactoryBot.create(:user, :traited)
+        TestProf::FactoryBot.set_factory_default(:user, :traited, user)
+      end
 
       it "re-uses default record for this trait" do
         post = TestProf::FactoryBot.create_default(:post)

--- a/spec/test_prof/factory_default_spec.rb
+++ b/spec/test_prof/factory_default_spec.rb
@@ -26,23 +26,29 @@ describe TestProf::FactoryDefault, :transactional do
   it "re-uses the same default record" do
     post = TestProf::FactoryBot.create(:post)
 
+    expect(TestProf::FactoryBot.get_factory_default(:user)).to eq user
     expect(post.user).to eq user
   end
 
   it "re-uses default record independently of traits" do
     post = TestProf::FactoryBot.create(:post, :with_traited_user)
 
+    expect(TestProf::FactoryBot.get_factory_default(:user)).to eq user
     expect(post.user).to eq user
   end
 
   it "re-uses default record independently of attributes" do
     post = TestProf::FactoryBot.create(:post, :with_tagged_user)
 
+    expect(TestProf::FactoryBot.get_factory_default(:user)).to eq user
     expect(post.user).to eq user
   end
 
   specify ".disable!(&block)" do
     post = TestProf::FactoryBot.skip_factory_default { TestProf::FactoryBot.create(:post) }
+
+    # get_factory_default should ignore disabled
+    expect(TestProf::FactoryBot.get_factory_default(:user)).to eq user
     expect(post.user).not_to eq(user)
   end
 
@@ -53,7 +59,10 @@ describe TestProf::FactoryDefault, :transactional do
       post = TestProf::FactoryBot.create_default(:post)
       post_traited = TestProf::FactoryBot.create(:post, :with_traited_user)
 
+      expect(TestProf::FactoryBot.get_factory_default(:post).user).to eq user
       expect(post.user).to eq user
+
+      expect(TestProf::FactoryBot.get_factory_default(:post, :with_traited_user)).to eq nil
       expect(post_traited.user).not_to eq user
     end
 
@@ -64,7 +73,9 @@ describe TestProf::FactoryDefault, :transactional do
         post = TestProf::FactoryBot.create_default(:post)
         post_traited = TestProf::FactoryBot.create(:post, :with_traited_user)
 
+        expect(TestProf::FactoryBot.get_factory_default(:post).user).to eq user
         expect(post.user).to eq user
+        expect(TestProf::FactoryBot.get_factory_default(:user, :traited)).to eq traited_user
         expect(post_traited.user).to eq traited_user
       end
     end
@@ -76,6 +87,7 @@ describe TestProf::FactoryDefault, :transactional do
     it "ignores default when explicit attributes don't match" do
       post = TestProf::FactoryBot.create(:post, :with_tagged_user)
 
+      expect(TestProf::FactoryBot.get_factory_default(:user, tag: "some tag")).to eq nil
       expect(post.user).not_to eq user
     end
 
@@ -84,6 +96,7 @@ describe TestProf::FactoryDefault, :transactional do
 
       post = TestProf::FactoryBot.create(:post, :with_tagged_user)
 
+      expect(TestProf::FactoryBot.get_factory_default(:user, tag: "some tag")).to eq user
       expect(post.user).to eq user
     end
   end


### PR DESCRIPTION
Adds a `FactoryBot.get_factory_default` method that allows users to retrieve the default for a given setup. Useful in cases where the factory default is desired but the record isn't directly created through factory bot (such as an after build hook)