### PR TITLE
chore: Change "haven's" to "haven't" in warning messages.

### DIFF
--- a/lib/test_prof/ruby_prof.rb
+++ b/lib/test_prof/ruby_prof.rb
@@ -166,7 +166,7 @@ module TestProf
           log :warn, <<~MSG
             RubyProf is activated globally, you cannot generate per-example report.
 
-            Make sure you haven's set the TEST_RUBY_PROF environmental variable.
+            Make sure you haven't set the TEST_RUBY_PROF environmental variable.
           MSG
           return
         end

--- a/lib/test_prof/stack_prof.rb
+++ b/lib/test_prof/stack_prof.rb
@@ -83,7 +83,7 @@ module TestProf
           log :warn, <<~MSG
             StackProf is activated globally, you cannot generate per-example report.
 
-            Make sure you haven's set the TEST_STACK_PROF environmental variable.
+            Make sure you haven't set the TEST_STACK_PROF environmental variable.
           MSG
           return false
         end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Hello! This PR corrects a couple of typos in the warning messages about global activation.

<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation

-->