### PR TITLE
feat: FactoryProf results to a JSON file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add support for dumping FactoryProf results in JSON format. ([@uzushino][])
+
 ## 1.3.0 (2023-11-21)
 
 - Add Vernier integration. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,3 +378,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@peret]: https://github.com/peret
 [@bf4]: https://github.com/bf4
 [@Vankiru]: https://github.com/Vankiru
+[@uzushino]: https://github.com/uzushino

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -54,6 +54,25 @@ And for every test run see the overall factories usage:
 [TEST PROF INFO] Time spent in factories: 04:31.222 (54% of total time)
 ```
 
+### Exporting profile results to a JSON file
+
+FactoryProf can save profile results as a JSON file.
+
+To use this feature, set the `FPROF` environment variable to `json`:
+
+```sh
+FPROF=json rspec
+
+# or
+FPROF=json bundle exec rake test
+```
+
+Example output:
+
+```
+[TEST PROF INFO] Profile results to JSON: tmp/test_prof/test-prof.result.json
+```
+
 ## Factory Flamegraph
 
 The most useful feature of FactoryProf is the _FactoryFlame_ report. That's the special interpretation of Brendan Gregg's [flame graphs](http://www.brendangregg.com/flamegraphs.html) which allows you to identify _factory cascades_.

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -3,6 +3,7 @@
 require "test_prof/factory_prof/printers/simple"
 require "test_prof/factory_prof/printers/flamegraph"
 require "test_prof/factory_prof/printers/nate_heckler"
+require "test_prof/factory_prof/printers/json"
 require "test_prof/factory_prof/factory_builders/factory_bot"
 require "test_prof/factory_prof/factory_builders/fabrication"
 
@@ -25,6 +26,8 @@ module TestProf
             Printers::Flamegraph
           when "nate_heckler"
             Printers::NateHeckler
+          when "json"
+            Printers::Json
           else
             Printers::Simple
           end

--- a/lib/test_prof/factory_prof/printers/json.rb
+++ b/lib/test_prof/factory_prof/printers/json.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_prof/ext/float_duration"
+
+module TestProf::FactoryProf
+  module Printers
+    module Json  # :nodoc: all
+      class << self
+        using TestProf::FloatDuration
+        include TestProf::Logging
+
+        def dump(result, start_time:)
+          return log(:info, "No factories detected") if result.raw_stats == {}
+
+          outpath = TestProf.artifact_path("test-prof.result.json")
+          File.write(outpath, convert_stats(result, start_time).to_json)
+
+          log :info, "Profile results to JSON: #{outpath}"
+        end
+
+        def convert_stats(result, start_time)
+          total_run_time = TestProf.now - start_time
+          total_count = result.stats.sum { |stat| stat[:total_count] }
+          total_top_level_count = result.stats.sum { |stat| stat[:top_level_count] }
+          total_time = result.stats.sum { |stat| stat[:top_level_time] }
+          total_uniq_factories = result.stats.map { |stat| stat[:name] }.uniq.count
+
+          {
+            total_count: total_count,
+            total_top_level_count: total_top_level_count,
+            total_time: total_time.duration,
+            total_run_time: total_run_time.duration,
+            total_uniq_factories: total_uniq_factories,
+
+            stats: result.stats
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -43,6 +43,13 @@ describe "FactoryProf" do
       expect(output).to include("FactoryFlame report generated: ")
     end
 
+    specify "with nate printer always enabled and json profiler", :aggregate_failures do
+      output = run_rspec("factory_prof_with_nate", env: {"FPROF" => "json"})
+
+      expect(output).to match(/Time spent in factories: \d{2}+:\d{2}\.\d{3} \([\d.]+% of total time\)/)
+      expect(output).to include("Profile results to JSON: ")
+    end
+
     context "when no fabrication installed" do
       specify "simple printer", :aggregate_failures do
         output = run_rspec("factory_prof_no_fabrication", env: {"FPROF" => "1"})

--- a/spec/test_prof/factory_prof/printers/json_spec.rb
+++ b/spec/test_prof/factory_prof/printers/json_spec.rb
@@ -1,57 +1,57 @@
 # frozen_string_literal: true
 
 describe TestProf::FactoryProf::Printers::Json do
-    let(:stacks) do
-      stacks = []
-      stacks << %i[user account]
-      stacks << %i[user account]
-      stacks << %i[post account user account]
-      stacks << %i[comment post]
-      stacks << %i[comment user account]
-      stacks << [:user]
-      stacks << [:account]
-      stacks
+  let(:stacks) do
+    stacks = []
+    stacks << %i[user account]
+    stacks << %i[user account]
+    stacks << %i[post account user account]
+    stacks << %i[comment post]
+    stacks << %i[comment user account]
+    stacks << [:user]
+    stacks << [:account]
+    stacks
+  end
+
+  let(:stats) do
+    {
+      user: {name: :user, total_count: 5, total_time: 1.0, top_level_count: 5, top_level_time: 0.1},
+      account: {name: :account, total_count: 6, total_time: 2.0, top_level_count: 6, top_level_time: 0.2},
+      comment: {name: :comment, total_count: 2, total_time: 3.0, top_level_count: 2, top_level_time: 0.3},
+      name: {name: :post, total_count: 2, total_time: 4.0, top_level_count: 0, top_level_time: 0.4}
+    }
+  end
+
+  let(:result) { TestProf::FactoryProf::Result.new(stacks, stats) }
+
+  describe "#dump" do
+    before do
+      allow(File).to receive(:write)
+      allow(TestProf).to receive(:artifact_path).and_return("test-prof.result.json")
     end
-  
-    let(:stats) do
-      {
-        user: {name: :user, total_count: 5, total_time: 1.0, top_level_count: 5, top_level_time: 0.1},
-        account: {name: :account, total_count: 6, total_time: 2.0, top_level_count: 6, top_level_time: 0.2},
-        comment: {name: :comment, total_count: 2, total_time: 3.0, top_level_count: 2, top_level_time: 0.3},
-        name: {name: :post, total_count: 2, total_time: 4.0, top_level_count: 0, top_level_time: 0.4}
-      }
-    end
-  
-    let(:result) { TestProf::FactoryProf::Result.new(stacks, stats) }
-  
-    describe "#dump" do
-      before do
-        allow(File).to receive(:write)
-        allow(TestProf).to receive(:artifact_path).and_return("test-prof.result.json")
-      end
-  
-      it "write json" do
-        described_class.dump(result, start_time: 0)
-        outpath = TestProf.artifact_path("test-prof.result.json")
-        expect(File).to have_received(:write).with(outpath, String).once
-      end
-    end
-  
-    describe "#convert_stats" do
-      before do
-        allow(TestProf).to receive(:now).and_return(2.0)
-      end
-  
-      it "calculates factories usage" do
-        stats = described_class.convert_stats(result, 0.0)
-  
-        expect(stats).to include({
-          total_count: 15,
-          total_top_level_count: 13,
-          total_time: "00:01.000",
-          total_run_time: "00:02.000",
-          total_uniq_factories: 4
-        })
-      end
+
+    it "write json" do
+      described_class.dump(result, start_time: 0)
+      outpath = TestProf.artifact_path("test-prof.result.json")
+      expect(File).to have_received(:write).with(outpath, String).once
     end
   end
+
+  describe "#convert_stats" do
+    before do
+      allow(TestProf).to receive(:now).and_return(2.0)
+    end
+
+    it "calculates factories usage" do
+      stats = described_class.convert_stats(result, 0.0)
+
+      expect(stats).to include({
+        total_count: 15,
+        total_top_level_count: 13,
+        total_time: "00:01.000",
+        total_run_time: "00:02.000",
+        total_uniq_factories: 4
+      })
+    end
+  end
+end

--- a/spec/test_prof/factory_prof/printers/json_spec.rb
+++ b/spec/test_prof/factory_prof/printers/json_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+describe TestProf::FactoryProf::Printers::Json do
+    let(:stacks) do
+      stacks = []
+      stacks << %i[user account]
+      stacks << %i[user account]
+      stacks << %i[post account user account]
+      stacks << %i[comment post]
+      stacks << %i[comment user account]
+      stacks << [:user]
+      stacks << [:account]
+      stacks
+    end
+  
+    let(:stats) do
+      {
+        user: {name: :user, total_count: 5, total_time: 1.0, top_level_count: 5, top_level_time: 0.1},
+        account: {name: :account, total_count: 6, total_time: 2.0, top_level_count: 6, top_level_time: 0.2},
+        comment: {name: :comment, total_count: 2, total_time: 3.0, top_level_count: 2, top_level_time: 0.3},
+        name: {name: :post, total_count: 2, total_time: 4.0, top_level_count: 0, top_level_time: 0.4}
+      }
+    end
+  
+    let(:result) { TestProf::FactoryProf::Result.new(stacks, stats) }
+  
+    describe "#dump" do
+      before do
+        allow(File).to receive(:write)
+        allow(TestProf).to receive(:artifact_path).and_return("test-prof.result.json")
+      end
+  
+      it "write json" do
+        described_class.dump(result, start_time: 0)
+        outpath = TestProf.artifact_path("test-prof.result.json")
+        expect(File).to have_received(:write).with(outpath, String).once
+      end
+    end
+  
+    describe "#convert_stats" do
+      before do
+        allow(TestProf).to receive(:now).and_return(2.0)
+      end
+  
+      it "calculates factories usage" do
+        stats = described_class.convert_stats(result, 0.0)
+  
+        expect(stats).to include({
+          total_count: 15,
+          total_top_level_count: 13,
+          total_time: "00:01.000",
+          total_run_time: "00:02.000",
+          total_uniq_factories: 4
+        })
+      end
+    end
+  end


### PR DESCRIPTION
### What is the purpose of this pull request?

The purpose of this pull request is to add a feature that allows saving FactoryProf results to a JSON file.

### What changes did you make? (overview)

I have added the feature to save the FactoryProf results as a JSON file when the environment variable `FPROP=json` is set.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

