### PR TITLE
refactor: avoid using activesupport's present? method

### DIFF
--- a/lib/test_prof/before_all.rb
+++ b/lib/test_prof/before_all.rb
@@ -66,7 +66,7 @@ module TestProf
       private
 
       def filters_apply?(metadata)
-        return true unless filters.present? && TestProf.rspec?
+        return true unless filters.is_a?(Hash) && TestProf.rspec?
 
         ::RSpec::Core::MetadataFilter.apply?(
           :all?,


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixes #284, for cases when test-prof is not used in the context of Rails (activesupport)

### What changes did you make? (overview)

Avoid using `present?` and instead solve this usage with Ruby std-lib code. I think `is_a?(Hash)` is kind of equivalent for this purpose.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change: I didn't know how/where to test this. I'm open to suggestions!
- [ ] I've added a Changelog entry
- [x] I've updated a documentation: no need for documentation as it's an internal change

-->
