### PR TITLE
add threshold config parameter for FactoryProf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## master (unreleased)
 
+- FactoryProf: Add threshold configuration parameter. ([@lHydra][])
+
+Now you can ignore factories which total number of calls is less than the provided threshold. To do this, specify
+the `FPROF_THRESHOLD=30` env var or set it through `FactoryProf` configuration:
+
+```ruby
+TestProf::FactoryProf.configure do |config|
+  config.threshold = 30
+end
+```
+
 ## 1.3.3 (2024-04-19)
 
 - Fix MemProf bugs. ([@palkan][])
@@ -390,3 +401,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@Vankiru]: https://github.com/Vankiru
 [@uzushino]: https://github.com/uzushino
 [@lioneldebauge]: https://github.com/lioneldebauge
+[@lHydra]: https://github.com/lHydra

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -73,7 +73,7 @@ Example output:
 [TEST PROF INFO] Profile results to JSON: tmp/test_prof/test-prof.result.json
 ```
 
-### Threshold config
+### Reducing the output
 
 When running FactoryProf, the output may contain a lot of lines for factories that has been used a few times.
 To avoid this and focus on the most important statistics you can specify a threshold value. Then you will be shown the factories whose total number exceeds the threshold.

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -119,6 +119,28 @@ The wider column the more often this stack appears.
 
 The `root` cell shows the total number of `create` calls.
 
+## Threshold config
+
+When running FactoryProf, the output may contain a lot of lines for factories that has been used a few times.
+To avoid this and focus on the most important statistics you can specify a threshold value. Then you will be shown the factories whose total number exceeds the threshold.
+
+To use threshold option set `FPROF_THRESHOLD` environment variable to `N` (where `N` is a threshold number):
+
+```sh
+FPROF=1 FPROF_THRESHOLD=30 rspec
+
+# or
+FPROF=1 FPROF_THRESHOLD=30 bundle exec rake test
+```
+
+Or you can set the threshold parameter through the `FactoryProf` configuration:
+
+```ruby
+TestProf::FactoryProf.configure do |config|
+  config.threshold = 30
+end
+```
+
 ## Acknowledgments
 
 - Thanks to [Martin Spier](https://github.com/spiermar) for [d3-flame-graph](https://github.com/spiermar/d3-flame-graph)

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -73,6 +73,28 @@ Example output:
 [TEST PROF INFO] Profile results to JSON: tmp/test_prof/test-prof.result.json
 ```
 
+### Threshold config
+
+When running FactoryProf, the output may contain a lot of lines for factories that has been used a few times.
+To avoid this and focus on the most important statistics you can specify a threshold value. Then you will be shown the factories whose total number exceeds the threshold.
+
+To use threshold option set `FPROF_THRESHOLD` environment variable to `N` (where `N` is a threshold number):
+
+```sh
+FPROF=1 FPROF_THRESHOLD=30 rspec
+
+# or
+FPROF=1 FPROF_THRESHOLD=30 bundle exec rake test
+```
+
+Or you can set the threshold parameter through the `FactoryProf` configuration:
+
+```ruby
+TestProf::FactoryProf.configure do |config|
+  config.threshold = 30
+end
+```
+
 ## Factory Flamegraph
 
 The most useful feature of FactoryProf is the _FactoryFlame_ report. That's the special interpretation of Brendan Gregg's [flame graphs](http://www.brendangregg.com/flamegraphs.html) which allows you to identify _factory cascades_.
@@ -118,28 +140,6 @@ create(:comment) #=> creates 5 records
 The wider column the more often this stack appears.
 
 The `root` cell shows the total number of `create` calls.
-
-## Threshold config
-
-When running FactoryProf, the output may contain a lot of lines for factories that has been used a few times.
-To avoid this and focus on the most important statistics you can specify a threshold value. Then you will be shown the factories whose total number exceeds the threshold.
-
-To use threshold option set `FPROF_THRESHOLD` environment variable to `N` (where `N` is a threshold number):
-
-```sh
-FPROF=1 FPROF_THRESHOLD=30 rspec
-
-# or
-FPROF=1 FPROF_THRESHOLD=30 bundle exec rake test
-```
-
-Or you can set the threshold parameter through the `FactoryProf` configuration:
-
-```ruby
-TestProf::FactoryProf.configure do |config|
-  config.threshold = 30
-end
-```
 
 ## Acknowledgments
 

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -111,10 +111,6 @@ module TestProf
         started_at = TestProf.now
 
         at_exit do
-          if config.simple? && config.threshold.positive?
-            @stats.select! { |_, factory_stat| factory_stat[:total_count] >= config.threshold }
-          end
-
           print(started_at)
         end
 
@@ -124,7 +120,7 @@ module TestProf
       def print(started_at)
         printer = config.printer
 
-        printer.dump(result, start_time: started_at)
+        printer.dump(result, start_time: started_at, threshold: config.threshold)
       end
 
       def start

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -38,10 +38,6 @@ module TestProf
       def flamegraph?
         @mode == :flamegraph
       end
-
-      def simple?
-        @mode == :simple
-      end
     end
 
     class Result # :nodoc:

--- a/lib/test_prof/factory_prof/printers/json.rb
+++ b/lib/test_prof/factory_prof/printers/json.rb
@@ -9,7 +9,7 @@ module TestProf::FactoryProf
         using TestProf::FloatDuration
         include TestProf::Logging
 
-        def dump(result, start_time:)
+        def dump(result, start_time:, **)
           return log(:info, "No factories detected") if result.raw_stats == {}
 
           outpath = TestProf.artifact_path("test-prof.result.json")

--- a/lib/test_prof/factory_prof/printers/nate_heckler.rb
+++ b/lib/test_prof/factory_prof/printers/nate_heckler.rb
@@ -10,7 +10,7 @@ module TestProf::FactoryProf
         using TestProf::FloatDuration
         include TestProf::Logging
 
-        def dump(result, start_time:)
+        def dump(result, start_time:, **)
           return if result.raw_stats == {}
 
           total_time = result.stats.sum { |stat| stat[:top_level_time] }

--- a/lib/test_prof/factory_prof/printers/simple.rb
+++ b/lib/test_prof/factory_prof/printers/simple.rb
@@ -9,7 +9,7 @@ module TestProf::FactoryProf
         using TestProf::FloatDuration
         include TestProf::Logging
 
-        def dump(result, start_time:)
+        def dump(result, start_time:, threshold:)
           return log(:info, "No factories detected") if result.raw_stats == {}
           msgs = []
 
@@ -32,6 +32,8 @@ module TestProf::FactoryProf
             MSG
 
           result.stats.each do |stat|
+            next if stat[:total_count] < threshold
+
             time_per_call = stat[:total_time] / stat[:total_count]
 
             msgs << format("%8d %11d %13.4fs %17.4fs %18.4fs %18s", stat[:total_count], stat[:top_level_count], stat[:total_time], time_per_call, stat[:top_level_time], stat[:name])

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -13,6 +13,17 @@ describe "FactoryProf" do
       expect(output).to match(/\s+16\s+8\s+(\d+\.\d{4}s\s+){3}user\n\s+10\s+6\s+\s+(\d+\.\d{4}s\s+){3}post/)
     end
 
+    specify "simple printer with threshold param", :aggregate_failures do
+      output = run_rspec("factory_prof", env: {"FPROF" => "1", "FPROF_THRESHOLD" => "11"})
+
+      expect(output).to include("FactoryProf enabled (simple mode)")
+
+      expect(output).to include("Factories usage")
+      expect(output).to match(/Total: 16\n\s+Total top-level: 8\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 1/)
+      expect(output).to match(/total\s+top-level\s+total time\s+time per call\s+top-level time\s+name/)
+      expect(output).to match(/\s+16\s+8\s+(\d+\.\d{4}s\s+){3}user\n/)
+    end
+
     specify "flamegraph printer" do
       output = run_rspec("factory_prof", env: {"FPROF" => "flamegraph"})
 

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -19,9 +19,10 @@ describe "FactoryProf" do
       expect(output).to include("FactoryProf enabled (simple mode)")
 
       expect(output).to include("Factories usage")
-      expect(output).to match(/Total: 16\n\s+Total top-level: 8\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 1/)
+      expect(output).to match(/Total: 26\n\s+Total top-level: 14\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
       expect(output).to match(/total\s+top-level\s+total time\s+time per call\s+top-level time\s+name/)
       expect(output).to match(/\s+16\s+8\s+(\d+\.\d{4}s\s+){3}user\n/)
+      expect(output).not_to match(/\s+10\s+6\s+\s+(\d+\.\d{4}s\s+){3}post/)
     end
 
     specify "flamegraph printer" do


### PR DESCRIPTION
### What is the purpose of this pull request?

Add threshold config parameter for `FactoryProf` to ignore factories which total number of calls is less than the provided threshold

### Is there anything you'd like reviewers to focus on?

I'm not sure if support for this option is needed for flamegraph mode? As of now, I have only added support for simple mode

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

Closes https://github.com/test-prof/test-prof/issues/290