### PR TITLE
add hooks parameter to vernier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## master (unreleased)
 
+- Vernier: Add hooks configuration parameter. ([@lHydra][])
+
+Now you can add more insights to the resulting report by adding event markers from Active Support Notifications.
+To do this, specify the `TEST_VERNIER_HOOKS=rails` env var or set it through `Vernier` configuration:
+
+```ruby
+TestProf::Vernier.configure do |config|
+  config.hooks = :rails
+end
+```
+
 ## 1.3.3 (2024-04-19)
 
 - Fix MemProf bugs. ([@palkan][])
@@ -390,3 +401,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@Vankiru]: https://github.com/Vankiru
 [@uzushino]: https://github.com/uzushino
 [@lioneldebauge]: https://github.com/lioneldebauge
+[@lHydra]: https://github.com/lHydra

--- a/docs/profilers/ruby_profilers.md
+++ b/docs/profilers/ruby_profilers.md
@@ -143,6 +143,25 @@ You can also profile your application boot process:
 TEST_VERNIER=boot bundle exec rspec ./spec/some_spec.rb
 ```
 
+### Add markers from  Active Support Notifications
+
+You can add more insights to the resulting report by adding event markers from Active Support Notifications:
+
+```sh
+TEST_VERNIER=1 TEST_VERNIER_HOOKS=rails bundle exec rake test
+
+# or for RSpec
+TEST_VERNIER=1 TEST_VERNIER_HOOKS=rails bundle exec rspec ...
+```
+
+Or you can set the hooks parameter through the `Vernier` configuration:
+
+```ruby
+TestProf::Vernier.configure do |config|
+  config.hooks = :rails
+end
+```
+
 ## RubyProf
 
 Easily integrate the power of [ruby-prof](https://github.com/ruby-prof/ruby-prof) into your test suite.

--- a/lib/test_prof/vernier.rb
+++ b/lib/test_prof/vernier.rb
@@ -19,7 +19,7 @@ module TestProf
   module Vernier
     # Vernier configuration
     class Configuration
-      attr_accessor :mode, :target, :interval
+      attr_accessor :mode, :target, :interval, :hooks
 
       def initialize
         @mode = ENV.fetch("TEST_VERNIER_MODE", :wall).to_sym
@@ -27,6 +27,7 @@ module TestProf
 
         sample_interval = ENV["TEST_VERNIER_INTERVAL"].to_i
         @interval = (sample_interval > 0) ? sample_interval : nil
+        @hooks = (ENV["TEST_VERNIER_HOOKS"] == "rails") ? :rails : nil
       end
 
       def boot?
@@ -82,6 +83,7 @@ module TestProf
         options = {}
 
         options[:interval] = config.interval if config.interval
+        options[:hooks] = config.hooks if config.hooks
 
         if block_given?
           options[:mode] = config.mode

--- a/lib/test_prof/vernier.rb
+++ b/lib/test_prof/vernier.rb
@@ -27,7 +27,7 @@ module TestProf
 
         sample_interval = ENV["TEST_VERNIER_INTERVAL"].to_i
         @interval = (sample_interval > 0) ? sample_interval : nil
-        @hooks = (ENV["TEST_VERNIER_HOOKS"] == "rails") ? :rails : nil
+        @hooks = ENV["TEST_VERNIER_HOOKS"]&.split(",")&.map { |hook| hook.strip.to_sym }
       end
 
       def boot?

--- a/spec/integrations/profilers_spec.rb
+++ b/spec/integrations/profilers_spec.rb
@@ -60,6 +60,15 @@ describe "general profilers", skip: !PROFILERS_AVAILABLE do
         expect(output).to include("Vernier report generated")
         expect(output).to include("0 failures")
       end
+
+      specify "with hooks vernier contains rails events" do
+        output = run_rspec("vernier", env: {"TEST_VERNIER_HOOKS" => "rails"})
+        sample_rails_event = "load_config_initializer.railties"
+        vernier_report = File.read("tmp/test_prof/vernier-report-wall--vernier_fixture-rb-1-1-.json")
+
+        expect(output).to include("0 failures")
+        expect(vernier_report).to match(/#{sample_rails_event}/)
+      end
     end
   end
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Add hooks configuration parameter for `TestProf::Vernier` to add event markers from Active Support Notifications

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

Closes https://github.com/test-prof/test-prof/issues/289
