### PR TITLE
Track traits and overrides with FactoryProf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Support latest Timecop patching `Process.clock_gettime`. ([@palkan][])
 
+- FactoryProf: Add variations information to the FactorProf data in simple mode. Add `variations_limit` configuration parameter. ([@lHydra][])
+
+Now you can see common variations (traits and attribute overrides) while collecting data with `FactoryProf`
+
 - Vernier: Add hooks configuration parameter. ([@lHydra][])
 
 Now you can add more insights to the resulting report by adding event markers from Active Support Notifications.

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -12,13 +12,19 @@ Total top-level: 10286
 Total time: 04:31.222 (out of 07.16.124)
 Total uniq factories: 119
 
- total   top-level   total time    time per call      top-level time            name
-  6091        2715    115.7671s          0.0426s            50.2517s            user
-  2142        2098     93.3152s          0.0444s            92.1915s            post
-  ...
+   name           total   top-level   total time    time per call      top-level time
+
+   user            6091        2715    115.7671s          0.0426s            50.2517s
+     .admin         123         715     15.7671s          0.0466s             5.2517s
+     [name,role]     25          11       7.671s          0.0666s             1.2517s
+   post            2142        2098     93.3152s          0.0444s            92.1915s
+     .draft[tags]    12          12       9.3152s          0.164s            42.1915s
+   ...
 ```
 
-It shows both the total number of the factory runs and the number of _top-level_ runs, i.e. not during another factory invocation (e.g. when using associations.)
+It shows both the total number of the factory and its variations (such as traits, overrides) runs and the number of _top-level_ runs, i.e. not during another factory invocation (e.g. when using associations.)
+
+In the example above, `.xxx` indicates a trait and `[a,b]` indicates the overrides keys, e.g., `create(:user, :admin)` is an `.admin` variation, while `create(:post, :draft, tags: ["a"])`—`.draft[tags]`
 
 It also shows the time spent generating records with factories and the amount of time taken per factory call.
 
@@ -92,6 +98,28 @@ Or you can set the threshold parameter through the `FactoryProf` configuration:
 ```ruby
 TestProf::FactoryProf.configure do |config|
   config.threshold = 30
+end
+```
+
+### Variations limit config
+
+When running FactoryProf, the output may contain a variant that is too long, which will distort the output.
+To avoid this and focus on the most important statistics you can specify a variations limit value. Then a special ID (`[...]`) will be shown instead of the variant with the number of traits/overrides exceeding the limit.
+
+To use variations limit parameter set `FPROF_VARIATIONS_LIMIT` environment variable to `N` (where `N` is a limit number):
+
+```sh
+FPROF=1 FPROF_VARIATIONS_LIMIT=5 rspec
+
+# or
+FPROF=1 FPROF_VARIATIONS_LIMIT=5 bundle exec rake test
+```
+
+Or you can set the limit parameter through the `FactoryProf` configuration:
+
+```ruby
+TestProf::FactoryProf.configure do |config|
+  config.variations_limit = 5
 end
 ```
 

--- a/lib/test_prof/factory_prof/fabrication_patch.rb
+++ b/lib/test_prof/factory_prof/fabrication_patch.rb
@@ -5,7 +5,13 @@ module TestProf
     # Wrap #run method with FactoryProf tracking
     module FabricationPatch
       def create(name, overrides = {})
-        FactoryBuilders::Fabrication.track(name) { super }
+        variation = ""
+
+        unless overrides.empty?
+          variation += overrides.keys.sort.to_s.gsub(/[\\":]/, "")
+        end
+
+        FactoryBuilders::Fabrication.track(name, variation: variation.to_sym) { super }
       end
     end
   end

--- a/lib/test_prof/factory_prof/factory_bot_patch.rb
+++ b/lib/test_prof/factory_prof/factory_bot_patch.rb
@@ -5,7 +5,19 @@ module TestProf
     # Wrap #run method with FactoryProf tracking
     module FactoryBotPatch
       def run(strategy = @strategy)
-        FactoryBuilders::FactoryBot.track(strategy, @name) { super }
+        variation = ""
+
+        if @traits || @overrides
+          unless @traits.empty?
+            variation += @traits.sort.join(".").prepend(".")
+          end
+
+          unless @overrides.empty?
+            variation += @overrides.keys.sort.to_s.gsub(/[\\":]/, "")
+          end
+        end
+
+        FactoryBuilders::FactoryBot.track(strategy, @name, variation: variation.to_sym) { super }
       end
     end
   end

--- a/lib/test_prof/factory_prof/factory_builders/fabrication.rb
+++ b/lib/test_prof/factory_prof/factory_builders/fabrication.rb
@@ -15,8 +15,8 @@ module TestProf
           end
         end
 
-        def self.track(factory, &block)
-          FactoryProf.track(factory, &block)
+        def self.track(factory, **opts, &block)
+          FactoryProf.track(factory, **opts, &block)
         end
       end
     end

--- a/lib/test_prof/factory_prof/factory_builders/factory_bot.rb
+++ b/lib/test_prof/factory_prof/factory_builders/factory_bot.rb
@@ -18,9 +18,9 @@ module TestProf
             defined? TestProf::FactoryBot
         end
 
-        def self.track(strategy, factory, &block)
+        def self.track(strategy, factory, **opts, &block)
           return yield unless strategy.create?
-          FactoryProf.track(factory, &block)
+          FactoryProf.track(factory, **opts, &block)
         end
       end
     end

--- a/lib/test_prof/factory_prof/printers/simple.rb
+++ b/lib/test_prof/factory_prof/printers/simple.rb
@@ -28,18 +28,33 @@ module TestProf::FactoryProf
                Total time: #{total_time.duration} (out of #{total_run_time.duration})
                Total uniq factories: #{total_uniq_factories}
 
-                 total   top-level     total time      time per call      top-level time               name
+                 name                    total   top-level     total time      time per call      top-level time
             MSG
 
           result.stats.each do |stat|
             next if stat[:total_count] < threshold
 
-            time_per_call = stat[:total_time] / stat[:total_count]
-
-            msgs << format("%8d %11d %13.4fs %17.4fs %18.4fs %18s", stat[:total_count], stat[:top_level_count], stat[:total_time], time_per_call, stat[:top_level_time], stat[:name])
+            msgs << format("%-3s%-20s %8d %11d %13.4fs %17.4fs %18.4fs", *format_args(stat))
+            # move other variation ("[...]") to the end of the array
+            sorted_variations = stat[:variations].sort_by.with_index do |variation, i|
+              (variation[:name] == "[...]") ? stat[:variations].size + 1 : i
+            end
+            sorted_variations.each do |variation_stat|
+              msgs << format("%-5s%-18s %8d %11d %13.4fs %17.4fs %18.4fs", *format_args(variation_stat))
+            end
           end
 
           log :info, msgs.join("\n")
+        end
+
+        private
+
+        def format_args(stat)
+          time_per_call = stat[:total_time] / stat[:total_count]
+          format_args = [""]
+          format_args += stat.values_at(:name, :total_count, :top_level_count, :total_time)
+          format_args << time_per_call
+          format_args << stat[:top_level_time]
         end
       end
     end

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -48,9 +48,9 @@ describe "FactoryProf" do
 
       expect(output).to include("Factories usage")
       expect(output).to match(/Total: 26\n\s+Total top-level: 14\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
-      expect(output).to match(/total\s+top-level\s+total time\s+time per call\s+top-level time\s+name/)
-      expect(output).to match(/\s+16\s+8\s+(\d+\.\d{4}s\s+){3}user\n/)
-      expect(output).not_to match(/\s+10\s+6\s+\s+(\d+\.\d{4}s\s+){3}post/)
+      expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
+      expect(output).to match(/user\s+16\s+8\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n/)
+      expect(output).not_to match(/\s+post\s+10\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n/)
     end
 
     specify "flamegraph printer" do

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -9,8 +9,36 @@ describe "FactoryProf" do
 
       expect(output).to include("Factories usage")
       expect(output).to match(/Total: 26\n\s+Total top-level: 14\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
-      expect(output).to match(/total\s+top-level\s+total time\s+time per call\s+top-level time\s+name/)
-      expect(output).to match(/\s+16\s+8\s+(\d+\.\d{4}s\s+){3}user\n\s+10\s+6\s+\s+(\d+\.\d{4}s\s+){3}post/)
+      expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
+      expect(output).to match(
+        /
+          user\s+16\s+8\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.with_posts\[name\]\s+1\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[name\]\s+1\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+post\s+10\s+6\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[user\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s
+        /x
+      )
+    end
+
+    specify "simple printer with variations", :aggregate_failures do
+      output = run_rspec("factory_prof_with_variations", env: {"FPROF" => "1", "FPROF_VARIATIONS_LIMIT" => "2"})
+
+      expect(output).to include("FactoryProf enabled (simple mode)")
+
+      expect(output).to include("Factories usage")
+      expect(output).to match(/Total: 25\n\s+Total top-level: 9\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
+      expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
+      expect(output).to match(
+        /
+          user\s+15\s+7\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.traited.with_posts\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[name\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[...\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+post\s+10\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[text,\suser\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s
+        /x
+      )
     end
 
     specify "simple printer with threshold param", :aggregate_failures do

--- a/spec/integrations/fixtures/rspec/factory_prof_with_variations_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_with_variations_fixture.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require_relative "../../../support/ar_models"
+require "test-prof"
+
+TestProf.configure do |config|
+  config.output_dir = "../../../../tmp/test_prof"
+end
+
+describe "User" do
+  context "created by factory_bot" do
+    context "with few traits" do
+      let!(:user_with_traits) { TestProf::FactoryBot.create(:user, :traited, :with_posts) }
+      let!(:user_with_same_traits) { TestProf::FactoryBot.create(:user, :with_posts, :traited) }
+
+      it "works" do
+        expect(true).to eq true
+      end
+    end
+
+    context "with many traits" do
+      let!(:user_over_limit) { TestProf::FactoryBot.create(:user, :with_posts, :traited, :other_trait, tag: "tag") }
+      let!(:another_user_over_limit) { TestProf::FactoryBot.create(:user, :with_posts, :traited, tag: "some tag") }
+
+      it "works" do
+        expect(true).to eq true
+      end
+    end
+  end
+
+  context "created by fabrication" do
+    let!(:user) { Fabricate(:user) }
+    let!(:another_user_1) { Fabricate(:user, name: "some name") }
+    let!(:another_user_2) { Fabricate(:user, name: "some name") }
+    let!(:post) { Fabricate(:post, user: user, text: "some text") }
+    let!(:post_with_same_overrides) { Fabricate(:post, text: "some text", user: user) }
+
+    it "works" do
+      expect(true).to eq true
+    end
+  end
+end

--- a/spec/test_prof/factory_prof/printers/json_spec.rb
+++ b/spec/test_prof/factory_prof/printers/json_spec.rb
@@ -15,10 +15,10 @@ describe TestProf::FactoryProf::Printers::Json do
 
   let(:stats) do
     {
-      user: {name: :user, total_count: 5, total_time: 1.0, top_level_count: 5, top_level_time: 0.1},
-      account: {name: :account, total_count: 6, total_time: 2.0, top_level_count: 6, top_level_time: 0.2},
-      comment: {name: :comment, total_count: 2, total_time: 3.0, top_level_count: 2, top_level_time: 0.3},
-      name: {name: :post, total_count: 2, total_time: 4.0, top_level_count: 0, top_level_time: 0.4}
+      user: {name: :user, total_count: 5, total_time: 1.0, top_level_count: 5, top_level_time: 0.1, variations: []},
+      account: {name: :account, total_count: 6, total_time: 2.0, top_level_count: 6, top_level_time: 0.2, variations: []},
+      comment: {name: :comment, total_count: 2, total_time: 3.0, top_level_count: 2, top_level_time: 0.3, variations: []},
+      name: {name: :post, total_count: 2, total_time: 4.0, top_level_count: 0, top_level_time: 0.4, variations: []}
     }
   end
 

--- a/spec/test_prof/factory_prof_spec.rb
+++ b/spec/test_prof/factory_prof_spec.rb
@@ -18,6 +18,7 @@ describe TestProf::FactoryProf, :transactional do
     xs.map do |x|
       expect(x.delete(:total_time)).to be_a(Float)
       expect(x.delete(:top_level_time)).to be_a(Float)
+      x[:variations] = without_time(x[:variations]) unless x[:variations].nil?
       x
     end
   end
@@ -74,13 +75,13 @@ describe TestProf::FactoryProf, :transactional do
         )
         expect(without_time(result.stats)).to eq(
           [
-            {name: :post, total_count: 1, top_level_count: 1},
-            {name: :user, total_count: 1, top_level_count: 0}
+            {name: :post, total_count: 1, top_level_count: 1, variations: []},
+            {name: :user, total_count: 1, top_level_count: 0, variations: []}
           ]
         )
       end
 
-      it "contains many stacks" do
+      it "contains many stacks with variations" do
         TestProf::FactoryBot.create_pair(:user)
         TestProf::FactoryBot.create(:post)
         TestProf::FactoryBot.create(:user, :with_posts)
@@ -95,8 +96,10 @@ describe TestProf::FactoryProf, :transactional do
         )
         expect(without_time(result.stats)).to eq(
           [
-            {name: :user, total_count: 6, top_level_count: 3},
-            {name: :post, total_count: 3, top_level_count: 1}
+            {name: :user, total_count: 6, top_level_count: 3, variations: [
+              {name: :".with_posts", top_level_count: 1, total_count: 1}
+            ]},
+            {name: :post, total_count: 3, top_level_count: 1, variations: []}
           ]
         )
       end
@@ -116,9 +119,9 @@ describe TestProf::FactoryProf, :transactional do
         expect(result.stacks.first).to eq([:user])
       end
 
-      it "contains many stacks" do
+      it "contains many stacks with variations" do
         Fabricate.times(2, :user)
-        Fabricate.create(:post)
+        Fabricate.create(:post, text: "some text")
         Fabricate.create(:user) { Fabricate.times(2, :post) }
 
         expect(result.stacks.size).to eq 4
@@ -131,8 +134,10 @@ describe TestProf::FactoryProf, :transactional do
         )
         expect(without_time(result.stats)).to eq(
           [
-            {name: :user, total_count: 6, top_level_count: 3},
-            {name: :post, total_count: 3, top_level_count: 1}
+            {name: :user, total_count: 6, top_level_count: 3, variations: []},
+            {name: :post, total_count: 3, top_level_count: 1, variations: [
+              {name: :"[text]", top_level_count: 1, total_count: 1}
+            ]}
           ]
         )
       end


### PR DESCRIPTION
### What is the purpose of this pull request?

Add factory variants (such as traits/overrides) to the output in simple mode. This information will also be in the resulting json file.

Add `variants_limit` config parameter for `FactoryProf` to use special ID (`[...]`) for factories with too many traits/overrides. The default value is 2.

### Is there anything you'd like reviewers to focus on?

1. Do we need default values for the variations limit?
2. Traits can still be long and accordingly the output gets messed up. I wanted to know if this is worth fixing, or is this behavior generally expected?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

Closes https://github.com/test-prof/test-prof/issues/292
