### PR TITLE
Fixed deprecation warning with ActiveRecord >= 7.2

### DIFF
--- a/lib/test_prof/before_all/adapters/active_record.rb
+++ b/lib/test_prof/before_all/adapters/active_record.rb
@@ -26,7 +26,7 @@ module TestProf
                 ::ActiveRecord::Base.connection_handler.connection_pool_list(*POOL_ARGS).filter_map { |pool|
                   begin
                     # ActiveRecord 7.2+ deprecated `ConnectionPool#connection` method in favour of `lease_connection`
-                    if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.2.0")
+                    if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.2.0")
                       pool.lease_connection
                     else
                       pool.connection

--- a/spec/test_prof/before_all/adapters/active_record_spec.rb
+++ b/spec/test_prof/before_all/adapters/active_record_spec.rb
@@ -12,7 +12,7 @@ require "test_prof/before_all/adapters/active_record"
 describe TestProf::BeforeAll::Adapters::ActiveRecord do
   context "when using single database", skip: (multi_db? ? "Using multiple databases" : nil) do
     let(:connection_pool) { ApplicationRecord.connection_pool }
-    let(:connection) { connection_pool.connection }
+    let(:connection) { connection_pool.lease_connection }
 
     describe ".begin_transaction" do
       subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.begin_transaction }

--- a/spec/test_prof/before_all/adapters/active_record_spec.rb
+++ b/spec/test_prof/before_all/adapters/active_record_spec.rb
@@ -12,7 +12,14 @@ require "test_prof/before_all/adapters/active_record"
 describe TestProf::BeforeAll::Adapters::ActiveRecord do
   context "when using single database", skip: (multi_db? ? "Using multiple databases" : nil) do
     let(:connection_pool) { ApplicationRecord.connection_pool }
-    let(:connection) { connection_pool.lease_connection }
+
+    let(:connection) do
+      if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.2.0")
+        connection_pool.lease_connection
+      else
+        connection_pool.connection
+      end
+    end
 
     describe ".begin_transaction" do
       subject { ::TestProf::BeforeAll::Adapters::ActiveRecord.begin_transaction }


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix for deprecation warning on ActiveRecord >= 7.2.

### What changes did you make? (overview)

Active Record 7.2 deprecated `ConnectionPool#connection` method in favor of `lease_connection` https://github.com/rails/rails/blob/v7.2.0/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L313.
I updated the code to use new method when possible.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
