### PR TITLE
fix: dont load active record connection in dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+## 1.4.1 (2024-08-20)
+- Skips loading the ActiveRecord adapter for runs where RSpec --dry-run mode is enabled. ([@devinburnette][])
+
 ## 1.4.0 (2024-08-12)
 
 - AnyFixture: Disable fixtures cache within _clean fixture_ context. Automatically _refind_ records when using `#fixture`. ([@palkan][])

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ else
 
   platform :jruby do
     gem "activerecord-jdbcsqlite3-adapter"
-    gem "activerecord", "~> 7.0"
   end
 
   gem "activerecord", "~> 7.0"

--- a/lib/test_prof/version.rb
+++ b/lib/test_prof/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TestProf
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/spec/test_prof/before_all_spec.rb
+++ b/spec/test_prof/before_all_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_prof/before_all"
+
+RSpec.describe TestProf::BeforeAll do
+  let(:adapter) { double("Adapter") }
+
+  before do
+    described_class.adapter = adapter
+  end
+
+  describe ".adapter" do
+    context "when adapter is set" do
+      it "returns the adapter" do
+        expect(described_class.adapter).to eq(adapter)
+      end
+    end
+
+    context "when adapter is not set" do
+      before do
+        described_class.adapter = nil
+      end
+
+      context "when dry run mode is not enabled" do
+        before do
+          allow(TestProf).to receive(:rspec?).and_return(false)
+          allow(RSpec.configuration).to receive(:dry_run?).and_return(false)
+        end
+
+        it "returns the ActiveRecord adapter" do
+          expect(described_class.adapter).to eq(TestProf::BeforeAll::Adapters::ActiveRecord)
+        end
+      end
+
+      context "when dry run mode is enabled" do
+        before do
+          allow(TestProf).to receive(:rspec?).and_return(true)
+          allow(RSpec.configuration).to receive(:dry_run?).and_return(true)
+        end
+
+        it "returns nil" do
+          expect(described_class.adapter).to eq(nil)
+        end
+      end
+    end
+  end
+
+  describe ".begin_transaction" do
+    it "calls begin_transaction on adapter" do
+      allow(adapter).to receive(:begin_transaction)
+      expect(adapter).to receive(:begin_transaction)
+
+      described_class.begin_transaction {}
+    end
+  end
+
+  describe ".rollback_transaction" do
+    it "calls rollback_transaction on adapter" do
+      allow(adapter).to receive(:rollback_transaction)
+      expect(adapter).to receive(:rollback_transaction)
+
+      described_class.rollback_transaction {}
+    end
+  end
+
+  describe ".setup_fixtures" do
+    context "when adapter supports setup_fixtures" do
+      it "calls setup_fixtures on adapter" do
+        test_object = double("TestObject")
+        allow(adapter).to receive(:setup_fixtures)
+        expect(adapter).to receive(:setup_fixtures).with(test_object)
+
+        described_class.setup_fixtures(test_object)
+      end
+    end
+
+    context "when adapter does not support setup_fixtures" do
+      it "raises ArgumentError" do
+        allow(adapter).to receive(:respond_to?).with(:setup_fixtures).and_return(false)
+
+        expect { described_class.setup_fixtures(double("TestObject")) }.to raise_error(ArgumentError, "Current adapter doesn't support #setup_fixtures")
+      end
+    end
+  end
+end
+
+describe TestProf::BeforeAll::Configuration do
+  let(:config) { described_class.new }
+
+  describe "#before" do
+    it "adds a before hook to the specified type" do
+      block = proc {}
+      config.before(:begin, &block)
+
+      expect(config.instance_variable_get(:@hooks)[:begin].before.map(&:block)).to include(block)
+    end
+
+    it "raises an error for invalid hook type" do
+      expect { config.before(:invalid_type) {} }.to raise_error(ArgumentError, "Unknown hook type: invalid_type. Valid types: begin, rollback")
+    end
+  end
+
+  describe "#after" do
+    it "adds an after hook to the specified type" do
+      block = proc {}
+      config.after(:rollback, &block)
+
+      expect(config.instance_variable_get(:@hooks)[:rollback].after.map(&:block)).to include(block)
+    end
+
+    it "raises an error for invalid hook type" do
+      expect { config.after(:invalid_type) {} }.to raise_error(ArgumentError, "Unknown hook type: invalid_type. Valid types: begin, rollback")
+    end
+  end
+
+  describe "#run_hooks" do
+    it "runs all before and after hooks for the specified type" do
+      block_before = proc {}
+      block_after = proc {}
+
+      config.before(:begin, &block_before)
+      config.after(:begin, &block_after)
+
+      expect(block_before).to receive(:call).once
+      expect(block_after).to receive(:call).once
+
+      config.run_hooks(:begin) {}
+    end
+
+    it "raises an error for invalid hook type" do
+      expect { config.run_hooks(:invalid_type) {} }.to raise_error(ArgumentError, "Unknown hook type: invalid_type. Valid types: begin, rollback")
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?
Was getting `PG::ConnectionBad` and `ActiveRecord::ConnectionNotEstablished` errors when I added `let_it_be` and ran some `rswag` rake tasks in development which runs tests in `--dry-run` mode.. I would expect `test-prof` functionality to be fully compatible with `rspec --dry-run`.. So I think the right behavior here is to skip setting up an active record connection when it's a `--dry-run` because it seems the current behavior of `rspec --dry-run` doesn't have any assumptions about having a running database.

### What changes did you make? (overview)
Moved the adapter require into the module so that it can be lazy loaded and protected behind a new conditional to determine if we're in rspec's dry-run mode

### Is there anything you'd like reviewers to focus on?
n/a

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation

-->
