### PR TITLE
Migrates to rubocop v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Updates Rubocop::Cop code to comply with most modern API. ([@aseroff][])
+
 ## 1.4.2 (2024-09-03) 🗓️
 
 - Ignore default scopes in `ActiveRecord::Base#refind`. ([@palkan][])

--- a/lib/test_prof/cops/rspec/aggregate_examples/its.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/its.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < ::RuboCop::Cop::Cop
+      class AggregateExamples < ::RuboCop::Cop::Base
         # @example `its`
         #
         #   # Supports regular `its` call with an attribute/method name,

--- a/lib/test_prof/cops/rspec/aggregate_examples/line_range_helpers.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/line_range_helpers.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < ::RuboCop::Cop::Cop
+      class AggregateExamples < ::RuboCop::Cop::Base
         # @internal Support methods for keeping newlines around examples.
         module LineRangeHelpers
           include RangeHelp

--- a/lib/test_prof/cops/rspec/aggregate_examples/matchers_with_side_effects.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/matchers_with_side_effects.rb
@@ -5,7 +5,7 @@ require "test_prof/cops/rspec/language"
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < ::RuboCop::Cop::Cop
+      class AggregateExamples < ::RuboCop::Cop::Base
         # When aggregated, the expectations will fail when not supposed to or
         # have a risk of not failing when expected to. One example is
         # `validate_presence_of :comment` as it leaves an empty comment after

--- a/lib/test_prof/cops/rspec/aggregate_examples/metadata_helpers.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/metadata_helpers.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < ::RuboCop::Cop::Cop
+      class AggregateExamples < ::RuboCop::Cop::Base
         # @internal
         #   Support methods for example metadata.
         #   Examples with similar metadata are grouped.

--- a/lib/test_prof/cops/rspec/aggregate_examples/node_matchers.rb
+++ b/lib/test_prof/cops/rspec/aggregate_examples/node_matchers.rb
@@ -5,7 +5,7 @@ require "test_prof/cops/rspec/language"
 module RuboCop
   module Cop
     module RSpec
-      class AggregateExamples < ::RuboCop::Cop::Cop
+      class AggregateExamples < ::RuboCop::Cop::Base
         # @internal
         #   Node matchers and searchers.
         module NodeMatchers

--- a/lib/test_prof/factory_doctor.rb
+++ b/lib/test_prof/factory_doctor.rb
@@ -105,10 +105,9 @@ module TestProf
       # Do not analyze code within the block
       def ignore
         @ignored = true
-        res = yield
+        yield
       ensure
         @ignored = false
-        res
       end
 
       def ignore!

--- a/lib/test_prof/factory_doctor.rb
+++ b/lib/test_prof/factory_doctor.rb
@@ -105,9 +105,10 @@ module TestProf
       # Do not analyze code within the block
       def ignore
         @ignored = true
-        yield
+        res = yield
       ensure
         @ignored = false
+        res
       end
 
       def ignore!


### PR DESCRIPTION
Fixes #311

### What is the purpose of this pull request?
Recent rubocop update introduced a depreciation warning for inheriting from RuboCop::Cop::Cop.
See [Rubocop's migration guide](https://github.com/rubocop/rubocop/blob/6b30b0323e5e6ca83067631f6cf2cbc13b6a8f92/docs/modules/ROOT/pages/v1_upgrade_notes.adoc#L12) for what they've documented about the changes.

### What changes did you make? (overview)

Changed inheritance of cops to inherit from ::Base. 
Updated add_offense method to comply with new API.
A few minor rubocop autocorrections 

### Is there anything you'd like reviewers to focus on?



### Checklist

- [ ❌ ] I've added tests for this change (But I made sure the existing tests were passing)
- [ ✅ ] I've added a Changelog entry
- [ - ] I've updated a documentation
