### PR TITLE
Fix/escaped single quote

### DIFF
--- a/lib/test_prof/rspec_stamp.rb
+++ b/lib/test_prof/rspec_stamp.rb
@@ -153,14 +153,16 @@ module TestProf
           end
         end
 
-        replacement = "\\1#{parsed.fname}#{need_parens ? "(" : " "}" \
-                      "#{[desc, tags_str, htags_str].compact.join(", ")}" \
-                      "#{need_parens ? ") " : " "}\\3"
+        replacement = proc do
+          $1 + "#{parsed.fname}#{need_parens ? "(" : " "}" \
+          "#{[desc, tags_str, htags_str].compact.join(", ")}" \
+          "#{need_parens ? ") " : " "}" + $3
+        end
 
         if config.dry_run?
-          log :info, "Patched: #{example.sub(EXAMPLE_RXP, replacement)}"
+          log :info, "Patched: #{example.sub(EXAMPLE_RXP, &replacement)}"
         else
-          example.sub!(EXAMPLE_RXP, replacement)
+          example.sub!(EXAMPLE_RXP, &replacement)
         end
         true
       end

--- a/spec/test_prof/rspec_stamp_spec.rb
+++ b/spec/test_prof/rspec_stamp_spec.rb
@@ -150,6 +150,29 @@ describe TestProf::RSpecStamp do
       end
     end
 
+    context "with escaped single quotes" do
+      let(:source) do
+        <<~CODE
+          it 'has a \\' in the description' do # with comment
+            expect(subject.body).to eq("Not Found")
+          end
+        CODE
+      end
+
+      let(:expected) do
+        <<~CODE
+          it "has a in the description", :todo do # with comment
+            expect(subject.body).to eq("Not Found")
+          end
+        CODE
+      end
+
+      specify do
+        is_expected.to eq 0
+        expect(code.join).to eq expected
+      end
+    end
+
     context "one-liner" do
       let(:source) do
         <<~CODE

--- a/spec/test_prof/rspec_stamp_spec.rb
+++ b/spec/test_prof/rspec_stamp_spec.rb
@@ -161,7 +161,7 @@ describe TestProf::RSpecStamp do
 
       let(:expected) do
         <<~CODE
-          it "has a in the description", :todo do # with comment
+          it "has a \\' in the description", :todo do # with comment
             expect(subject.body).to eq("Not Found")
           end
         CODE

--- a/spec/test_prof/rspec_stamp_spec.rb
+++ b/spec/test_prof/rspec_stamp_spec.rb
@@ -32,7 +32,7 @@ describe TestProf::RSpecStamp do
   end
 
   describe ".apply_tags" do
-    let(:code) { source.split("\n") }
+    let(:code) { source.split("\n").map { _1 + "\n" } }
 
     let(:lines) { [1] }
 
@@ -58,7 +58,7 @@ describe TestProf::RSpecStamp do
 
     specify do
       is_expected.to eq 0
-      expect(code.join("\n")).to eq expected.strip
+      expect(code.join).to eq expected
     end
 
     context "with several examples" do
@@ -98,7 +98,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
 
       context "patch all" do
@@ -122,7 +122,7 @@ describe TestProf::RSpecStamp do
 
         specify do
           is_expected.to eq 0
-          expect(code.join("\n")).to eq expected.strip
+          expect(code.join).to eq expected
         end
       end
     end
@@ -146,7 +146,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
     end
 
@@ -165,7 +165,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
     end
 
@@ -184,7 +184,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
     end
 
@@ -207,7 +207,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
     end
 
@@ -232,7 +232,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
 
       context "with existing tags" do
@@ -254,7 +254,7 @@ describe TestProf::RSpecStamp do
 
         specify do
           is_expected.to eq 0
-          expect(code.join("\n")).to eq expected.strip
+          expect(code.join).to eq expected
         end
       end
 
@@ -279,7 +279,7 @@ describe TestProf::RSpecStamp do
 
         specify do
           is_expected.to eq 0
-          expect(code.join("\n")).to eq expected.strip
+          expect(code.join).to eq expected
         end
       end
     end
@@ -298,7 +298,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 1
-        expect(code.join("\n")).to eq source.strip
+        expect(code.join).to eq source
       end
     end
 
@@ -343,7 +343,7 @@ describe TestProf::RSpecStamp do
 
       specify do
         is_expected.to eq 0
-        expect(code.join("\n")).to eq expected.strip
+        expect(code.join).to eq expected
       end
 
       context "with existing tags" do
@@ -373,7 +373,7 @@ describe TestProf::RSpecStamp do
 
         specify do
           is_expected.to eq 0
-          expect(code.join("\n")).to eq expected.strip
+          expect(code.join).to eq expected
         end
       end
 
@@ -402,7 +402,7 @@ describe TestProf::RSpecStamp do
 
         specify do
           is_expected.to eq 0
-          expect(code.join("\n")).to eq expected.strip
+          expect(code.join).to eq expected
         end
       end
     end


### PR DESCRIPTION
Related to https://github.com/test-prof/test-prof/issues/313

This is a PR with some changes to the rstamp_tests to more closely reflect reality and a test case to illustrate the behavior in this issue.

### Test Changes

When RStamp reads in files it uses `File.readlines` which results in array of strings ending in newlines:

```rb
# somefile.rb
puts 'foo'
puts 'bar'

# somewhere else
File.readlines('somefile.rb')
=> ["puts 'foo'\n", "puts 'bar'\n"]
```

Meanwhile in the tests we take a heredoc and split it along the newline:

```rb
let(:source) do
  <<~CODE
    it "doesn't do what it should do" do
      expect(subject.body).to eq("OK")
    end
  CODE
end

let(:code) { source.split("\n") }

code
=> ["it \"doesn't do what it should do\" do", "expect(subject.body).to eq(\"OK\")", "end"]
```

This means that the code inputs do not have trailing newlines. It does not matter with the current test cases BUT with those changes the following added test case fails.

```rb
context "with escaped single quotes" do
  let(:source) do
    <<~code
      it 'has a \\' in the description' do # with comment
        expect(subject.body).to eq("not found")
      end
    code
  end

  let(:expected) do
    <<~code
      it "has a in the description", :todo do # with comment
        expect(subject.body).to eq("not found")
      end
    code
  end

  specify do
    is_expected.to eq 0
    expect(code.join).to eq expected
  end
end
```

### Failing Test Case

The reason the test case fails is the following code

```rb
# lib/test_prof/rspec_stamp.rb
def stamp_example(example, tags)
  # ...
  replacement = "\\1#{parsed.fname}#{need_parens ? "(" : " "}" \
                "#{[desc, tags_str, htags_str].compact.join(", ")}" \
                "#{need_parens ? ") " : " "}\\3"
  # replacement => "\\1it \"has a \\' in the description\", :todo \\3"

  # EXAMPLE_RXP = /(\s*)(\w+\s*(?:.*)\s*)(do|{)/.freeze
  example.sub!(EXAMPLE_RXP, replacement)
```

In this case the `\\1` and `\\3` will get replacement with their respective match groups, but the `\'` got escaped in such a way that is has turned into a match group. `$'` is a global variable that holds the match group for the string after the match [(see here)](https://docs.ruby-lang.org/en/2.2.0/Regexp.html#class-Regexp-label-Special+global+variables). So anything after `do` or `{` could be replaced there, except only in this case is it valid syntax.

### Fixing

I am not sure what the best fix is but I feel it would be something revolving around not modifying the strings in the `stamp_example` function and instead building up a replacement string and passing it back. However, I am unsure if this edge case merits the rework and if there was some other reason that the string were modified in place.

I do find the modification of strings in place to be pretty surprising.

