### PR TITLE
Add YJIT detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add a warning to check if YJIT is enabled, as it is known to slow down test environments. ([@yaroslav][])
+
 ## 1.4.3 (2024-12-18)
 
 - Fix handling new (lazy) connection pools in `before_all`. ([@palkan][])
@@ -449,3 +451,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@lHydra]: https://github.com/lHydra
 [@john-h-k]: https://github.com/john-h-k
 [@devinburnette]: https://github.com/devinburnette
+[@yaroslav]: https://github.com/yaroslav

--- a/lib/test_prof.rb
+++ b/lib/test_prof.rb
@@ -15,3 +15,4 @@ require "test_prof/tag_prof"
 require "test_prof/tps_prof"
 require "test_prof/rspec_dissect" if TestProf.rspec?
 require "test_prof/factory_all_stub"
+require "test_prof/yjit"

--- a/lib/test_prof/yjit.rb
+++ b/lib/test_prof/yjit.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module TestProf
+  # YJIT checker.
+  #
+  # Complains about YJIT being turned on, as it is designed for production
+  # environments and it is known to slowdown test suites.
+  #
+  # It is currently not possible to programmatically disable YJIT, only to
+  # enable it. If once it becomes possible, we should disable it by default.
+  #
+  # @see https://github.com/rails/rails/pull/53746
+  module YJIT
+    class << self
+      include Logging
+
+      def check!
+        return unless enabled?
+
+        complain if defined?(RubyVM) && defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+      end
+
+      private
+
+      def complain
+        log(:warn, <<~MSG)
+          YJIT is enabled. It is designed for production environments and is known to slow down test suites. You should disable it for better test performance.
+        MSG
+
+        if yjit_via_env?
+          log(:warn, <<~MSG)
+            It looks like YJIT is enabled via an environment variable, `RUBY_YJIT_ENABLE`. Consider removing it.
+          MSG
+        else
+          log(:warn, <<~MSG)
+            Check your code for `RubyVM::YJIT.enable` call, or your scripts for the `--yjit` flag.
+          MSG
+        end
+
+        log(:warn, <<~MSG)
+
+          If you wish to disable this warning, run with `YJIT_PROF=0`.
+
+        MSG
+      end
+
+      def enabled?
+        !ENV.key?("YJIT_PROF") || !%w[0 false].include?(ENV["YJIT_PROF"])
+      end
+
+      def yjit_via_env?
+        ENV.key?("RUBY_YJIT_ENABLE")
+      end
+    end
+  end
+end
+
+TestProf::YJIT.check!

--- a/spec/integrations/fixtures/rspec/dummy_fixture.rb
+++ b/spec/integrations/fixtures/rspec/dummy_fixture.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require "test-prof"
+
+TestProf.configure do |config|
+  config.output_dir = "../../../../tmp/test_prof"
+end
+
+describe "dummy" do
+  it "always passes" do
+    expect(true).to eq true
+  end
+end

--- a/spec/integrations/yjit_spec.rb
+++ b/spec/integrations/yjit_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe TestProf::YJIT do
+  context "with YJIT usage warning" do
+    context "by default" do
+      specify "stays silent" do
+        output = run_rspec("sample")
+
+        expect(output).to_not include("YJIT")
+      end
+    end
+
+    # Note that we should not really enable YJIT here to test if it detects
+    # actual usage (`RubyVM::YJIT.enabled?`), as it is currently
+    # impossible to programmatically disable it after enabling.
+    context "with YJIT enabled" do
+      specify "warns about using YJIT" do
+        output = run_rspec("dummy", env: {"RUBY_YJIT_ENABLE" => "1"})
+
+        expect(output).to include("YJIT")
+        expect(output).to include("RUBY_YJIT_ENABLE")
+      end
+
+      context "when turned off" do
+        specify "does not warn about using YJIT" do
+          output = run_rspec("dummy",
+            env: {"RUBY_YJIT_ENABLE" => "1", "YJIT_PROF" => "0"})
+
+          expect(output).to_not include("YJIT")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ads simple YJIT detection and warnings.

It would be great if we could disable YJIT when enabled, but it is currently not possible.

Reasoning:

On dev machines, a developer might have set up YJIT by default, because it is cool and someone recommended it. On production, people might test in a production environment, the same Rails runs in, or using a third party pre-setup container that launches Ruby with YJIT because it is "faster". In reality, they are losing %% of their test suite performance.

