### PR TITLE
feat: add Printer::SimpleTruncated that truncates overly long names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+- feat: add Printer::SimpleTruncated that truncates overly long names ([@skaestle][])
+
+`FPROF=truncated <your test command>`.
+
 ## 1.4.4 (2025-01-03)
 
 - Fix _stamping_ specs with single quotes with RSpec Stamp. ([@elasticspoon][])

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -39,6 +39,8 @@ FPROF=1 rspec
 FPROF=1 bundle exec rake test
 ```
 
+If you wish to truncate long names in the output you can do so via `FPROF=truncated`.
+
 ### [_Nate Heckler_](https://twitter.com/nateberkopec/status/1389945187766456333) mode
 
 To encourage you to fix your factories as soon as possible, we also have a special _Nate heckler_ mode.

--- a/lib/test_prof/factory_prof.rb
+++ b/lib/test_prof/factory_prof.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_prof/factory_prof/printers/simple"
+require "test_prof/factory_prof/printers/simple_truncated"
 require "test_prof/factory_prof/printers/flamegraph"
 require "test_prof/factory_prof/printers/nate_heckler"
 require "test_prof/factory_prof/printers/json"
@@ -28,6 +29,8 @@ module TestProf
             Printers::NateHeckler
           when "json"
             Printers::Json
+          when "truncated"
+            Printers::SimpleTruncated
           else
             Printers::Simple
           end

--- a/lib/test_prof/factory_prof/printers/simple.rb
+++ b/lib/test_prof/factory_prof/printers/simple.rb
@@ -4,7 +4,7 @@ require "test_prof/ext/float_duration"
 
 module TestProf::FactoryProf
   module Printers
-    module Simple # :nodoc: all
+    class Simple # :nodoc: all
       class << self
         using TestProf::FloatDuration
         include TestProf::Logging
@@ -34,7 +34,7 @@ module TestProf::FactoryProf
           result.stats.each do |stat|
             next if stat[:total_count] < threshold
 
-            msgs << format("%-3s%-20s %8d %11d %13.4fs %17.4fs %18.4fs", *format_args(stat))
+            msgs << formatted(3, 20, stat)
             # move other variation ("[...]") to the end of the array
             sorted_variations = stat[:variations].sort_by.with_index do |variation, i|
               (variation[:name] == "[...]") ? stat[:variations].size + 1 : i
@@ -42,7 +42,7 @@ module TestProf::FactoryProf
             sorted_variations.each do |variation_stat|
               next if variation_stat[:total_count] < threshold
 
-              msgs << format("%-5s%-18s %8d %11d %13.4fs %17.4fs %18.4fs", *format_args(variation_stat))
+              msgs << formatted(5, 18, variation_stat)
             end
           end
 
@@ -51,12 +51,20 @@ module TestProf::FactoryProf
 
         private
 
+        def formatted(indent, name, stat)
+          format(format_string(indent, name), *format_args(stat))
+        end
+
         def format_args(stat)
           time_per_call = stat[:total_time] / stat[:total_count]
           format_args = [""]
           format_args += stat.values_at(:name, :total_count, :top_level_count, :total_time)
           format_args << time_per_call
           format_args << stat[:top_level_time]
+        end
+
+        def format_string(indent, name)
+          "%-#{indent}s%-#{name}s %8d %11d %13.4fs %17.4fs %18.4fs"
         end
       end
     end

--- a/lib/test_prof/factory_prof/printers/simple_truncated.rb
+++ b/lib/test_prof/factory_prof/printers/simple_truncated.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TestProf::FactoryProf
+  module Printers
+    class SimpleTruncated < Simple # :nodoc: all
+      class << self
+        private
+
+        def format_string(indent, name)
+          "%-#{indent}s%-#{name}.#{name}s %8d %11d %13.4fs %17.4fs %18.4fs"
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/factory_prof_spec.rb
+++ b/spec/integrations/factory_prof_spec.rb
@@ -8,12 +8,13 @@ describe "FactoryProf" do
       expect(output).to include("FactoryProf enabled (simple mode)")
 
       expect(output).to include("Factories usage")
-      expect(output).to match(/Total: 26\n\s+Total top-level: 14\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
+      expect(output).to match(/Total: 30\n\s+Total top-level: 18\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 3/)
       expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
       expect(output).to match(
         /
           user\s+16\s+8\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
           \s+post\s+10\s+6\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+supercalifragilisticexpialidocious\s+4\s+4\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
         /x
       )
     end
@@ -24,7 +25,7 @@ describe "FactoryProf" do
       expect(output).to include("FactoryProf enabled (simple mode)")
 
       expect(output).to include("Factories usage")
-      expect(output).to match(/Total: 25\n\s+Total top-level: 9\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
+      expect(output).to match(/Total: 29\n\s+Total top-level: 13\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 3/)
       expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
       expect(output).to match(
         /
@@ -36,6 +37,10 @@ describe "FactoryProf" do
           \s+post\s+10\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
           \s+-\s+8\s+0\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
           \s+\[text,\suser\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s
+          \s+supercalifragilisticexpialidocious\s+4\s+4\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.other_trait_with_very_long_name\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.traited\[tag\]\s+1\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[...\]\s+1\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
         /x
       )
     end
@@ -46,7 +51,7 @@ describe "FactoryProf" do
       expect(output).to include("FactoryProf enabled (simple mode)")
 
       expect(output).to include("Factories usage")
-      expect(output).to match(/Total: 26\n\s+Total top-level: 14\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 2/)
+      expect(output).to match(/Total: 30\n\s+Total top-level: 18\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 3/)
       expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
       expect(output).to match(/user\s+16\s+8\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n/)
       expect(output).not_to match(/\s+post\s+10\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n/)
@@ -105,6 +110,48 @@ describe "FactoryProf" do
         expect(output).to include("No factories detected")
         expect(output).not_to include("[TEST PROF ERROR]")
       end
+    end
+
+    specify "simple printer truncated", :aggregate_failures do
+      output = run_rspec("factory_prof", env: {"FPROF" => "truncated"})
+      expect(output).to include("FactoryProf enabled (simple mode)")
+
+      expect(output).to include("Factories usage")
+      expect(output).to match(/Total: 30\n\s+Total top-level: 18\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 3/)
+      expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
+      expect(output).to match(
+        /
+          user\s+16\s+8\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+post\s+10\s+6\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+supercalifragilis...\s+4\s+4\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+        /x
+      )
+    end
+
+    specify "simple printer truncated with variations", :aggregate_failures do
+      output = run_rspec("factory_prof_with_variations", env: {"FPROF" => "truncated", "FPROF_VARS" => "1", "FPROF_VARIATIONS_LIMIT" => "2"})
+
+      expect(output).to include("FactoryProf enabled (simple mode)")
+
+      expect(output).to include("Factories usage")
+      expect(output).to match(/Total: 29\n\s+Total top-level: 13\n\s+Total time: \d{2}+:\d{2}\.\d{3} \(out of \d{2}+:\d{2}\.\d{3}\)\n\s+Total uniq factories: 3/)
+      expect(output).to match(/name\s+total\s+top-level\s+total time\s+time per call\s+top-level time/)
+      expect(output).to match(
+        /
+          user\s+15\s+7\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+-\s+9\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.traited.with_p...\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[name\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[...\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+post\s+10\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+-\s+8\s+0\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[text,\suser\]\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s
+          \s+supercalifragilis...\s+4\s+4\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.other_trait_wi...\s+2\s+2\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+.traited\[tag\]\s+1\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+          \s+\[...\]\s+1\s+1\s+(\d+\.\d{4}s\s+){2}\d+\.\d{4}s\n
+        /x
+      )
     end
   end
 end

--- a/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_fixture.rb
@@ -71,3 +71,25 @@ describe "Post" do
     end
   end
 end
+
+describe "Supercalifragilisticexpialidocious" do
+  let(:factory) { :supercalifragilisticexpialidocious }
+
+  context "created by factory_bot" do
+    let(:supercali) { TestProf::FactoryBot.create(factory) }
+
+    it "generates random names" do
+      supercali2 = TestProf::FactoryBot.create(factory)
+      expect(supercali.name).not_to eq supercali2.name
+    end
+  end
+
+  context "created by fabrication" do
+    let(:supercali) { Fabricate(factory) }
+
+    it "generates random names" do
+      supercali2 = Fabricate(factory)
+      expect(supercali.name).not_to eq supercali2.name
+    end
+  end
+end

--- a/spec/integrations/fixtures/rspec/factory_prof_with_variations_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_with_variations_fixture.rb
@@ -41,3 +41,29 @@ describe "User" do
     end
   end
 end
+
+describe "Supercalifragilisticexpialidocious" do
+  let(:factory) { :supercalifragilisticexpialidocious }
+  let(:trait) { :other_trait_with_very_long_name }
+  let(:other_trait) { :traited }
+
+  context "created by factory_bot" do
+    context "with few traits" do
+      let!(:user_with_traits) { TestProf::FactoryBot.create(factory, trait) }
+      let!(:user_with_same_traits) { TestProf::FactoryBot.create(factory, trait) }
+
+      it "works" do
+        expect(true).to eq true
+      end
+    end
+
+    context "with many traits" do
+      let!(:user_over_limit) { TestProf::FactoryBot.create(factory, trait, other_trait, tag: "tag") }
+      let!(:another_user_over_limit) { TestProf::FactoryBot.create(factory, other_trait, tag: "some tag") }
+
+      it "works" do
+        expect(true).to eq true
+      end
+    end
+  end
+end

--- a/spec/support/ar_models.rb
+++ b/spec/support/ar_models.rb
@@ -115,6 +115,11 @@ unless ENV["DRY_RUN"] == "true"
       t.foreign_key :users
       t.timestamps
     end
+
+    create_table :supercalifragilisticexpialidocious, id: (using_pg ? :uuid : :bigint), if_not_exists: true do |t|
+      t.string :name
+      t.string :tag
+    end
   end
 
   ActiveRecord::Base.establish_connection DB_CONFIG_COMMENTS if multi_db?
@@ -155,6 +160,16 @@ class Post < ApplicationRecord
   belongs_to :user
 
   attr_accessor :dirty
+end
+
+class Supercalifragilisticexpialidocious < ApplicationRecord
+  validates :name, presence: true
+
+  def clone
+    copy = dup
+    copy.name = "#{name} (cloned)"
+    copy
+  end
 end
 
 TestProf::FactoryBot.define do
@@ -212,6 +227,18 @@ TestProf::FactoryBot.define do
       end
     end
   end
+
+  factory :supercalifragilisticexpialidocious do
+    sequence(:name) { |n| "John #{n}" }
+
+    trait :traited do
+      tag { "traited" }
+    end
+
+    trait :other_trait_with_very_long_name do
+      tag { "other_trait_with_very_long_name" }
+    end
+  end
 end
 
 Fabricator(:user) do
@@ -225,4 +252,8 @@ end
 
 Fabricator(:alice_post, from: :post) do
   user { Fabricate(:user, name: "Alice") }
+end
+
+Fabricator(:supercalifragilisticexpialidocious) do
+  name { sequence(:name) { |n| "John #{n}" } }
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

To keep the table layout intact, overly long factory-names (and traits)  can be truncated

`FPROF=1` will output:

```
[TEST PROF INFO] Factories usage

 Total: 29
 Total top-level: 13
 Total time: 00:00.032 (out of 00:00.521)
 Total uniq factories: 3

   name                    total   top-level     total time      time per call      top-level time

   user                       15           7        0.0297s            0.0020s             0.0263s
     -                         9           1        0.0075s            0.0008s             0.0041s
     .traited.with_posts        2           2        0.0133s            0.0067s             0.0133s
     [name]                    2           2        0.0009s            0.0005s             0.0009s
     [...]                     2           2        0.0079s            0.0039s             0.0079s
   post                       10           2        0.0131s            0.0013s             0.0014s
     -                         8           0        0.0117s            0.0015s             0.0000s
     [text, user]              2           2        0.0014s            0.0007s             0.0014s
   supercalifragilisticexpialidocious        4           4        0.0046s            0.0011s             0.0046s
     .other_trait_with_very_long_name        2           2        0.0034s            0.0017s             0.0034s
     .traited[tag]             1           1        0.0006s            0.0006s             0.0006s
     [...]                     1           1        0.0006s            0.0006s             0.0006s
```

`FPROF=truncated` will output:

```
[TEST PROF INFO] Factories usage

 Total: 29
 Total top-level: 13
 Total time: 00:00.033 (out of 00:00.515)
 Total uniq factories: 3

   name                    total   top-level     total time      time per call      top-level time

   user                       15           7        0.0316s            0.0021s             0.0279s
     -                         9           1        0.0079s            0.0009s             0.0043s
     .traited.with_post        2           2        0.0144s            0.0072s             0.0144s
     [name]                    2           2        0.0009s            0.0005s             0.0009s
     [...]                     2           2        0.0083s            0.0041s             0.0083s
   post                       10           2        0.0170s            0.0017s             0.0011s
     -                         8           0        0.0158s            0.0020s             0.0000s
     [text, user]              2           2        0.0011s            0.0006s             0.0011s
   supercalifragilistic        4           4        0.0048s            0.0012s             0.0048s
     .other_trait_with_        2           2        0.0034s            0.0017s             0.0034s
     .traited[tag]             1           1        0.0008s            0.0008s             0.0008s
     [...]                     1           1        0.0006s            0.0006s             0.0006s
```
 
### What changes did you make? (overview)

- refactored `Printers::Simple` to allow changin the format-string
- introduced new Printer: `Printers::SimpleTruncated` (subclass of `Printers::Simple`) that uses truncating format-string

### Is there anything you'd like reviewers to focus on?

- I'm not sure how to deal with code-duplication without changing `module Printers::Simple` to `class Printers::Simple`. I appreciate any input how to do that and sticking with the `module` (as to not be different than the other `Printers`

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
