### PR TITLE
Mention vernier.prof, a tenderlove/profiler host

### DIFF
--- a/docs/profilers/ruby_profilers.md
+++ b/docs/profilers/ruby_profilers.md
@@ -120,7 +120,7 @@ At the end of the test run, you will see the message from Test Prof including th
 [TEST PROF INFO] Vernier report generated: tmp/test_prof/vernier-report-wall-raw-total.json
 ```
 
-Use the [profile-viewer](https://github.com/tenderlove/profiler/tree/ruby) gem or upload your profiles to [profiler.firefox.com](https://profiler.firefox.com).
+Use the [profile-viewer](https://github.com/tenderlove/profiler/tree/ruby) gem or upload your profiles to [vernier.prof](https://vernier.prof). Alternatively, you can use [profiler.firefox.com](https://profiler.firefox.com) which profile-viewer is a fork of.
 
 ### Profiling individual examples with Vernier
 


### PR DESCRIPTION
This seems to have been added last year in vernier's readme: https://github.com/jhawthorn/vernier/commit/70d463c860fc7d6ff1f3dec392a6c984745c4254

It's an instance of the tenderlove/profiler firefox profiler fork, which means it's much more suitable for ruby. In my limited testing, only the fork was able to show source.

Apologies if I misunderstood or missed something, this is my first time using both this gem and vernier.