### PR TITLE
Fixed the width of the name column

### DIFF
--- a/lib/test_prof/factory_prof/printers/simple.rb
+++ b/lib/test_prof/factory_prof/printers/simple.rb
@@ -19,6 +19,12 @@ module TestProf::FactoryProf
           total_time = result.stats.sum { |stat| stat[:top_level_time] }
           total_uniq_factories = result.stats.map { |stat| stat[:name] }.uniq.count
 
+          table_indent = 3
+          variations_indent = 2
+          max_name_length = result.stats.map { _1[:name].length }.max
+          max_variation_length = result.stats.flat_map { _1[:variations] }.select(&:present?).map { _1[:name].length }.max || 0
+          name_column_length = truncate_names ? 20 : ([max_name_length, max_variation_length].max + variations_indent)
+
           msgs <<
             <<~MSG
               Factories usage
@@ -27,14 +33,24 @@ module TestProf::FactoryProf
                Total top-level: #{total_top_level_count}
                Total time: #{total_time.duration} (out of #{total_run_time.duration})
                Total uniq factories: #{total_uniq_factories}
-
-                 name                    total   top-level     total time      time per call      top-level time
             MSG
+
+          msgs << format(
+            "%#{table_indent}s%-#{name_column_length}s %8s %12s %13s %16s %17s",
+            "", "name", "total", "top-level", "total time", "time per call", "top-level time"
+          )
+          msgs << ""
 
           result.stats.each do |stat|
             next if stat[:total_count] < threshold
 
-            msgs << formatted(3, 20, truncate_names, stat)
+            msgs << formatted(
+              table_indent,
+              name_column_length,
+              truncate_names,
+              stat
+            )
+
             # move other variation ("[...]") to the end of the array
             sorted_variations = stat[:variations].sort_by.with_index do |variation, i|
               (variation[:name] == "[...]") ? stat[:variations].size + 1 : i
@@ -42,7 +58,12 @@ module TestProf::FactoryProf
             sorted_variations.each do |variation_stat|
               next if variation_stat[:total_count] < threshold
 
-              msgs << formatted(5, 18, truncate_names, variation_stat)
+              msgs << formatted(
+                table_indent + variations_indent,
+                name_column_length - variations_indent,
+                truncate_names,
+                variation_stat
+              )
             end
           end
 
@@ -65,7 +86,7 @@ module TestProf::FactoryProf
 
         def format_string(indent_len, name_len, truncate_names)
           name_format = truncate_names ? "#{name_len}.#{name_len}" : name_len.to_s
-          "%-#{indent_len}s%-#{name_format}s %8d %11d %13.4fs %17.4fs %18.4fs"
+          "%#{indent_len}s%-#{name_format}s %8d %12d %12.4fs %15.4fs %16.4fs"
         end
       end
     end


### PR DESCRIPTION
### What is the purpose of this pull request?
When factories with long names are used, FactoryProf stats get disjointed.

### What changes did you make? (overview)
Before
```
[TEST PROF INFO] Factories usage

 Total: 30
 Total top-level: 18
 Total time: 00:00.013 (out of 00:00.343)
 Total uniq factories: 3

   name                    total   top-level     total time      time per call      top-level time

   user                       16           8        0.0137s            0.0009s             0.0104s
   post                       10           6        0.0072s            0.0007s             0.0020s
   supercalifragilisticexpialidocious        4           4        0.0014s            0.0003s             0.0014s
```
After
```
[TEST PROF INFO] Factories usage

 Total: 30
 Total top-level: 18
 Total time: 00:00.019 (out of 00:00.362)
 Total uniq factories: 3

   name                                    total    top-level    total time    time per call    top-level time

   user                                       16            8       0.0120s          0.0008s           0.0107s
   post                                       10            6       0.0055s          0.0006s           0.0021s
   supercalifragilisticexpialidocious          4            4       0.0064s          0.0016s           0.0064s
```

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
