### PR TITLE
Remove FactoryGirl references in favor of FactoryBot

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 **Ruby Version:**
 
-**Framework Version (RSpec, Minitest, FactoryGirl, Rails, whatever):**
+**Framework Version (RSpec, Minitest, FactoryBot, Rails, whatever):**
 
 **TestProf Version:**
 

--- a/docs/profilers/event_prof.md
+++ b/docs/profilers/event_prof.md
@@ -155,9 +155,9 @@ end
 
 ### `"factory.create"`
 
-FactoryGirl provides its own instrumentation ('factory_girl.run_factory'); but there is a caveat – it fires an event every time a factory is used, even when we use factory for nested associations. Thus it's not possible to calculate the total time spent in factories due to the double calculation.
+FactoryBot provides its own instrumentation ('factory_bot.run_factory'); but there is a caveat – it fires an event every time a factory is used, even when we use factory for nested associations. Thus it's not possible to calculate the total time spent in factories due to the double calculation.
 
-EventProf comes with a little patch for FactoryGirl which provides instrumentation only for top-level `FactoryGirl.create` calls. It is loaded automatically if you use `"factory.create"` event:
+EventProf comes with a little patch for FactoryBot which provides instrumentation only for top-level `FactoryBot.create` calls. It is loaded automatically if you use `"factory.create"` event:
 
 ```sh
 EVENT_PROF=factory.create bundle exec rspec

--- a/docs/profilers/factory_doctor.md
+++ b/docs/profilers/factory_doctor.md
@@ -3,7 +3,7 @@
 One common bad pattern that slows our tests down is unnecessary database manipulation. Consider a _bad_ example:
 
 ```ruby
-# with FactoryBot/FactoryGirl
+# with FactoryBot
 it "validates name presence" do
   user = create(:user)
   user.name = ""
@@ -21,7 +21,7 @@ end
 Here we create a new user record, run all callbacks and validations and save it to the database. We don't need all these! Here is a _good_ example:
 
 ```ruby
-# with FactoryBot/FactoryGirl
+# with FactoryBot
 it "validates name presence" do
   user = build_stubbed(:user)
   user.name = ""
@@ -36,7 +36,7 @@ it "validates name presence" do
 end
 ```
 
-Read more about [`build_stubbed`](https://robots.thoughtbot.com/use-factory-girls-build-stubbed-for-a-faster-test).
+Read more about [`build_stubbed`](https://thoughtbot.com/blog/use-factory-bots-build-stubbed-for-a-faster-test).
 
 FactoryDoctor is a tool that helps you identify such _bad_ tests, i.e. tests that perform unnecessary database queries.
 
@@ -73,7 +73,7 @@ end
 
 FactoryDoctor supports:
 
-- FactoryGirl/FactoryBot
+- FactoryBot
 - Fabrication.
 
 ### RSpec

--- a/docs/profilers/factory_prof.md
+++ b/docs/profilers/factory_prof.md
@@ -23,11 +23,11 @@ It shows both the total number of the factory runs and the number of _top-level_
 
 It also shows the time spent generating records with factories and the amount of time taken per factory call.
 
-**NOTE**: FactoryProf only tracks the database-persisted factories. In case of FactoryGirl/FactoryBot these are the factories provided by using `create` strategy. In case of Fabrication - objects that created using `create` method.
+**NOTE**: FactoryProf only tracks the database-persisted factories. In case of FactoryBot these are the factories provided by using `create` strategy. In case of Fabrication - objects that created using `create` method.
 
 ## Instructions
 
-FactoryProf can be used with FactoryGirl/FactoryBot or Fabrication - application can be bundled with both gems at the same time.
+FactoryProf can be used with FactoryBot or Fabrication - application can be bundled with both gems at the same time.
 
 To activate FactoryProf use `FPROF` environment variable:
 

--- a/docs/recipes/factory_all_stub.md
+++ b/docs/recipes/factory_all_stub.md
@@ -1,10 +1,10 @@
 # FactoryAllStub
 
-_Factory All Stub_ is a spell to force FactoryBot/FactoryGirl use only `build_stubbed` strategy (even if you call `create` or `build`).
+_Factory All Stub_ is a spell to force FactoryBot use only `build_stubbed` strategy (even if you call `create` or `build`).
 
 The idea behind it is to quickly fix [Factory Doctor](../profilers/factory_doctor.md) offenses (and even do that automatically).
 
-**NOTE**. Only works with FactoryGirl/FactoryBot. Should be considered only as a temporary specs fix.
+**NOTE**. Only works with FactoryBot. Should be considered only as a temporary specs fix.
 
 ## Instructions
 

--- a/lib/test_prof/event_prof/custom_events/factory_create.rb
+++ b/lib/test_prof/event_prof/custom_events/factory_create.rb
@@ -29,7 +29,7 @@ TestProf::EventProf::CustomEvents.register("factory.create") do
     TestProf.log(
       :error,
       <<~MSG
-        Failed to load factory_bot / factory_girl / fabrication.
+        Failed to load factory_bot / fabrication.
 
         Make sure that any of them is in your Gemfile.
       MSG

--- a/lib/test_prof/factory_all_stub.rb
+++ b/lib/test_prof/factory_all_stub.rb
@@ -12,7 +12,7 @@ module TestProf
 
     class << self
       def init
-        # Monkey-patch FactoryBot / FactoryGirl
+        # Monkey-patch FactoryBot
         TestProf::FactoryBot::FactoryRunner.prepend(FactoryBotPatch) if
           defined?(TestProf::FactoryBot)
       end

--- a/lib/test_prof/factory_bot.rb
+++ b/lib/test_prof/factory_bot.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 module TestProf # :nodoc: all
-  FACTORY_GIRL_NAMES = {"factory_bot" => "::FactoryBot", "factory_girl" => "::FactoryGirl"}.freeze
-
   TestProf.require("active_support")
 
-  FACTORY_GIRL_NAMES.find do |name, cname|
-    TestProf.require(name) do
-      TestProf::FactoryBot = Object.const_get(cname)
-    end
+  TestProf.require("factory_bot") do
+    TestProf::FactoryBot = Object.const_get("::FactoryBot")
   end
 end

--- a/lib/test_prof/factory_doctor.rb
+++ b/lib/test_prof/factory_doctor.rb
@@ -71,7 +71,7 @@ module TestProf
 
         log :info, "FactoryDoctor enabled (event: \"#{config.event}\", threshold: #{config.threshold})"
 
-        # Monkey-patch FactoryBot / FactoryGirl
+        # Monkey-patch FactoryBot
         TestProf::FactoryBot::FactoryRunner.prepend(FactoryBotPatch) if
           defined?(TestProf::FactoryBot)
 

--- a/lib/test_prof/factory_prof/factory_builders/factory_bot.rb
+++ b/lib/test_prof/factory_prof/factory_builders/factory_bot.rb
@@ -12,7 +12,7 @@ module TestProf
       class FactoryBot
         using TestProf::FactoryBotStrategy
 
-        # Monkey-patch FactoryBot / FactoryGirl
+        # Monkey-patch FactoryBot
         def self.patch
           TestProf::FactoryBot::FactoryRunner.prepend(FactoryBotPatch) if
             defined? TestProf::FactoryBot

--- a/spec/integrations/fixtures/rspec/factory_prof_no_factory_bot_fixture.rb
+++ b/spec/integrations/fixtures/rspec/factory_prof_no_factory_bot_fixture.rb
@@ -2,13 +2,12 @@
 
 $LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
 
-$LOAD_PATH.delete_if { |p| (p =~ /factory_girl/) || (p =~ /factory_bot/) }
+$LOAD_PATH.delete_if { |p| p =~ /factory_bot/ }
 
 require "test-prof"
 
 context "when no factory_bot installed" do
   it "do nothing" do
-    expect { FactoryGirl.create(:user) }.to raise_error(NameError)
     expect { FactoryBot.create(:user) }.to raise_error(NameError)
     expect(true).to eq true
   end


### PR DESCRIPTION
### What is the purpose of this pull request?

I found the term "FactoryGirl" while reading the [document](https://test-prof.evilmartians.io/profilers/event_prof?id=custom-events), which seemed a bit outdated. Initially, I thought we should keep both terms like "FactoryGirl/FactoryBot" as it was written in other places.

However, I noticed that this gem specifies `gem "factory_bot", ">= 6.0"` in its Gemfile, and I wonder if this gem no longer supports factory_girl since version 4.8.2 (when it was [renamed](https://thoughtbot.com/blog/factory_bot) to factory_bot in 2017) or version 4.9.0 (the [last version of factory_girl](https://rubygems.org/gems/factory_girl/versions/4.9.0?locale=en)).

### What changes did you make? (overview)

Therefore, I've removed all references to FactoryGirl from both the documentation and codebase. If this change is inappropriate, please feel free to let me know or close this PR.

### Is there anything you'd like reviewers to focus on?

N/A

### Checklist

- I've added tests for this change
- [ ] I've added a Changelog entry
    - I'll add it if necessary.
- [x] I've updated a documentation
