### PR TITLE
RubyProf: explicitly require 'rspec-core' dependency

### DIFF
--- a/lib/test_prof/ruby_prof/rspec.rb
+++ b/lib/test_prof/ruby_prof/rspec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rspec/core"
+
 require "test_prof/utils/rspec"
 
 module TestProf


### PR DESCRIPTION
Should resolve https://github.com/test-prof/test-prof/issues/337
