### PR TITLE
Add logger as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add `logger` as a runtime dependency (it's no longer a default gem in Ruby 4.0). ([@moznion][])
+
 ## 1.6.1 (2026-04-02)
 
 - Require MFA to publish the gem.
@@ -506,3 +508,4 @@ See [changelog](https://github.com/test-prof/test-prof/blob/v0.8.0/CHANGELOG.md)
 [@elasticspoon]: https://github.com/elasticspoon
 [@Rylan12]: https://github.com/Rylan12
 [@kddnewton]: https://github.com/kddnewton
+[@moznion]: https://github.com/moznion

--- a/test-prof.gemspec
+++ b/test-prof.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
+  spec.add_dependency "logger"
+
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec-rails", ">= 4.0"


### PR DESCRIPTION
### What is the purpose of this pull request?

`lib/test_prof/core.rb` requires "logger", which is no longer a default gem as of Ruby 4.0.
ref: https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/#stdlib-updates

This might become the issue of `LoadError: cannot load such file -- logger` so it'd be better to fix this problem.

Similar issues:

- https://github.com/phusion/passenger/issues/2642
- https://github.com/aws/aws-sdk-ruby/issues/3206
- https://github.com/sidekiq/sidekiq/issues/6319

### What changes did you make? (overview)

Declare it explicitly so test-prof does not rely on it being pulled in transitively (e.g. via activesupport).

### Is there anything you'd like reviewers to focus on?

n/a

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
