### PR TITLE
Fix RSpecDissect crash when let is evaluated on a non-example thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix `RSpecDissect` crashing with `undefined method 'last' for nil` when a `let` is evaluated on a non-example thread (e.g. a Capybara `:js`/system spec server thread). The span-stack thread-local is now lazily initialized so off-example-thread access is a safe no-op.
+
 ## 1.6.1 (2026-04-02)
 
 - Require MFA to publish the gem.

--- a/lib/test_prof/rspec_dissect.rb
+++ b/lib/test_prof/rspec_dissect.rb
@@ -86,11 +86,11 @@ module TestProf
       end
 
       def current_span
-        Thread.current[:_rspec_dissect_spans_stack].last
+        span_stack.last
       end
 
       def span_stack
-        Thread.current[:_rspec_dissect_spans_stack]
+        Thread.current[:_rspec_dissect_spans_stack] ||= []
       end
 
       def track(type, id: nextid, **meta)

--- a/spec/bugs/fixtures/rspec_dissect_cross_thread_fixture.rb
+++ b/spec/bugs/fixtures/rspec_dissect_cross_thread_fixture.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+require "test-prof"
+
+# Evaluating a memoized helper (`let`) from a thread other than the RSpec
+# example thread must not crash RSpecDissect. The span-stack thread-local is
+# only initialized on the example thread; reading a `let` elsewhere (e.g. a
+# Capybara server thread) previously raised `NoMethodError: undefined method
+# 'last' for nil`.
+describe "Something" do
+  let(:value) { 42 }
+
+  it "reads a let from another thread" do
+    result = nil
+    Thread.new { result = value }.join
+    expect(result).to eq 42
+  end
+end

--- a/spec/bugs/rspec_dissect_cross_thread_spec.rb
+++ b/spec/bugs/rspec_dissect_cross_thread_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+describe "RSpecDissect with cross-thread let", type: :integration do
+  specify do
+    output = run_rspec(
+      "rspec_dissect_cross_thread",
+      chdir: File.join(__dir__, "fixtures"),
+      env: {"RD_PROF" => "1"}
+    )
+
+    expect(output).to include("1 example, 0 failures")
+    expect(output).to include("RSpecDissect report")
+  end
+end


### PR DESCRIPTION
RSpecDissect stores its span stack in a thread-local (Thread.current[:_rspec_dissect_spans_stack]) that is only initialized via reset! on the RSpec example thread. When a memoized helper (let) is evaluated on a different thread -- most commonly a Capybara :js/system spec, where the app runs in a separate Puma server thread -- current_span and track dereference the uninitialized thread-local and raise NoMethodError: undefined method 'last' for nil.

Lazily initialize the span stack in span_stack so access from a non-example thread is a safe no-op (spans created off the example thread are simply not collected as part of that example's setup timing). This fixes both current_span and the << / pop in track.

Introduced in 1.6.0 with the RSpecDissect let-breakdowns feature; 1.5.2 is unaffected.

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation

-->


Closes #347