### PR TITLE
Add support for FlameGraphPrinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## 1.6.2 (2026-07-10)
+
+- Add support for ruby-prof's FlameGraphPrinter
+
 ## 1.6.1 (2026-04-02)
 
 - Require MFA to publish the gem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## master (unreleased)
 
-## 1.6.2 (2026-07-10)
-
 - Add support for ruby-prof's FlameGraphPrinter
 
 ## 1.6.1 (2026-04-02)

--- a/lib/test_prof/ruby_prof.rb
+++ b/lib/test_prof/ruby_prof.rb
@@ -31,7 +31,8 @@ module TestProf
         "." => "DotPrinter",
         "call_stack" => "CallStackPrinter",
         "call_tree" => "CallTreePrinter",
-        "multi" => "MultiPrinter"
+        "multi" => "MultiPrinter",
+        "flame_graph" => "FlameGraphPrinter"
       }.freeze
 
       # Mapping from printer to report file extension
@@ -40,7 +41,8 @@ module TestProf
         "graph_html" => "html",
         "dot" => "dot",
         "." => "dot",
-        "call_stack" => "html"
+        "call_stack" => "html",
+        "flame_graph" => "html"
       }.freeze
 
       LOGFILE_PREFIX = "ruby-prof-report"

--- a/spec/test_prof/ruby_prof_spec.rb
+++ b/spec/test_prof/ruby_prof_spec.rb
@@ -117,5 +117,21 @@ describe TestProf::RubyProf do
 
       expect(File.exist?(File.join(TestProf.config.output_dir, "ruby-prof-report-call_stack-cpu-stub-123454321.html"))).to eq true
     end
+
+    specify "with flame_graph printer" do
+      described_class.config.printer = :flame_graph
+      described_class.config.exclude_common_methods = false
+      described_class.config.test_prof_exclusions_enabled = false
+
+      expect(profile).to receive(:exclude_common_methods!).never
+
+      stub_const("RubyProf::FlameGraphPrinter", printer_class)
+      expect(printer_class).to receive(:new).with(result).and_return(printer)
+      expect(printer).to receive(:print).with(anything, min_percent: 1).and_return("")
+
+      subject.dump("stub")
+
+      expect(File.exist?(File.join(TestProf.config.output_dir, "ruby-prof-report-flame_graph-wall-stub.html"))).to eq true
+    end
   end
 end


### PR DESCRIPTION
FlameGraphPrinter was added in
https://github.com/ruby-prof/ruby-prof/commit/4eddb90 and test-prof could support that format.

### What is the purpose of this pull request?

Enable `flamegraph` HTML profiles, as supported by `ruby-prof`.

### What changes did you make? (overview)

Add a `flame_graph` option that calls to `ruby-prof`'s `FlameGraphPrinter`.

### Is there anything you'd like reviewers to focus on?

Is this following the project's conventions?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation