### PR TITLE
Fix before_all with parallel Minitest 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix `before_all` with parallel Minitest 6. ([@GabrielNagy][])
+
 ## 1.6.3 (2026-07-20)
 
 - Fix `before_all` firing N times in Minitest 6. ([@palkan][])

--- a/lib/test_prof/recipes/minitest/before_all.rb
+++ b/lib/test_prof/recipes/minitest/before_all.rb
@@ -3,22 +3,13 @@
 require "test_prof/before_all"
 
 Minitest.singleton_class.prepend(Module.new do
-  attr_reader :previous_klass
+  attr_accessor :previous_klass
   @previous_klass = nil
+end)
 
-  # Minitest 6+
-  if Minitest::Runnable.method_defined?(:run_suite)
-    def run(klass, *rest)
-      return super unless klass.respond_to?(:parallelized) && klass.parallelized
-
-      if @previous_klass && @previous_klass != klass
-        @previous_klass.before_all_executor&.deactivate!
-      end
-      @previous_klass = klass
-
-      super
-    end
-  else
+# Minitest 5
+unless Minitest::Runnable.respond_to?(:run_suite)
+  Minitest.singleton_class.prepend(Module.new do
     def run_one_method(klass, *rest)
       return super unless klass.respond_to?(:parallelized) && klass.parallelized
 
@@ -29,8 +20,8 @@ Minitest.singleton_class.prepend(Module.new do
 
       super
     end
-  end
-end)
+  end)
+end
 
 module TestProf
   module BeforeAll
@@ -115,6 +106,24 @@ module TestProf
           base.extend ClassMethods
 
           base.cattr_accessor :parallelized
+          # Minitest 6+
+          if ::Minitest::Runnable.respond_to?(:run_suite)
+            base.prepend(Module.new do
+              def run(*)
+                klass = self.class
+                return super unless klass.parallelized
+
+                previous_klass = ::Minitest.previous_klass
+                if previous_klass && previous_klass != klass
+                  previous_klass.before_all_executor&.deactivate!
+                end
+                ::Minitest.previous_klass = klass
+
+                super
+              end
+            end)
+          end
+
           if base.respond_to?(:parallelize_teardown)
             base.parallelize_teardown do
               last_klass = ::Minitest.previous_klass

--- a/spec/bugs/fixtures/before_all_minitest_six_fixture.rb
+++ b/spec/bugs/fixtures/before_all_minitest_six_fixture.rb
@@ -29,3 +29,46 @@ class BeforeAllCountTest < Minitest::Test
     assert true
   end
 end
+
+class ParallelBeforeAllCleanupTest < Minitest::Test
+  def test_deactivates_the_previous_parallelized_class
+    first_test = build_parallelized_test
+    second_test = build_parallelized_test
+
+    first_result = run_test_case(first_test)
+    assert_predicate first_result, :passed?
+    assert_predicate first_test.before_all_executor, :active?
+
+    second_result = run_test_case(second_test)
+    assert_predicate second_result, :passed?
+    refute_predicate first_test.before_all_executor, :active?
+    assert_predicate second_test.before_all_executor, :active?
+  ensure
+    first_test&.before_all_executor&.deactivate!
+    second_test&.before_all_executor&.deactivate!
+  end
+
+  private
+
+  def run_test_case(klass)
+    if Minitest::Runnable.respond_to?(:run_suite)
+      klass.new(:run_manually).run
+    else
+      Minitest.run_one_method(klass, :run_manually)
+    end
+  end
+
+  def build_parallelized_test
+    Class.new(Minitest::Test) do
+      include TestProf::BeforeAll::Minitest
+
+      self.parallelized = true
+
+      before_all {}
+
+      def run_manually
+        assert true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Minitest 6 defines `run_suite` as a [class method](https://github.com/minitest/minitest/blob/v6.0.6/lib/minitest.rb#L452-L486), but the existing check looked for an instance method. `TestProf` therefore installed the Minitest 5 `run_one_method` hook, which made Rails [call a method](https://github.com/rails/rails/blob/v8.0.5/activesupport/lib/active_support/testing/parallelization/worker.rb#L49-L54
) that Minitest 6 no longer provides.

### What changes did you make? (overview)

Detect Minitest 6 through its class API and hook the per-test run method that Rails 8 workers use. Keep the existing `run_one_method` path for Minitest 5.

### Is there anything you'd like reviewers to focus on?

Here's a repro script which fails on master and passes with this PR:
```ruby
require "minitest"
require "minitest/test"
require "active_support/core_ext/module/attribute_accessors"
require "test_prof/recipes/minitest/before_all"

TestProf::BeforeAll.adapter = TestProf::BeforeAll::NoopAdapter

class ExampleTest < Minitest::Test
  include TestProf::BeforeAll::Minitest

  before_all { @value = 1 }

  def test_value
    assert_equal 1, @value
  end
end

# This is the same API choice that a Rails parallel worker makes.
result = if Minitest.respond_to?(:run_one_method)
  Minitest.run_one_method(ExampleTest, :test_value)
else
  ExampleTest.new(:test_value).run
end

puts "Manual run passed: #{result.passed?}"
```

```sh-session
> BUNDLE_GEMFILE=gemfiles/activerecord8.gemfile bundle exec ruby -Ilib repro.rb
~/code/test-prof/lib/test_prof/recipes/minitest/before_all.rb:23:in 'run_one_method': super: no superclass method 'run_one_method' for module Minitest (NoMethodError)
        from repro.rb:20:in '<main>'
```

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation

